### PR TITLE
Add notebook generation step to Copilot API update workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,9 +14,22 @@ You are working on the **autofit_workspace**, a tutorial/example repository for 
 
 `run_scripts.sh` sets `PYAUTOFIT_TEST_MODE=1` automatically. Every script should pass in this mode. A script that fails in test mode indicates a real problem (broken import, wrong function name, etc.).
 
+## Notebook Generation
+
+After all scripts pass testing, regenerate the notebooks:
+
+```bash
+pip install ipynb-py-convert
+git clone https://github.com/Jammy2211/PyAutoBuild.git ../PyAutoBuild
+PYTHONPATH=../PyAutoBuild/autobuild python3 ../PyAutoBuild/autobuild/generate.py autofit
+```
+
+Run this from the workspace root. Commit the regenerated notebooks alongside the script changes.
+
 ## PR Description
 
 When opening your PR, include:
 - A summary of which APIs changed and how
 - A list of all scripts you updated
+- Confirmation that notebooks were regenerated
 - A "Could not update" section for any scripts that still fail, with the error and your assessment of why

--- a/.github/workflows/api-update.yml
+++ b/.github/workflows/api-update.yml
@@ -131,6 +131,13 @@ jobs:
           4. Test your changes by running: \`bash run_scripts.sh\`
           5. Fix any test failures and re-run until the test suite is clean.
           6. If a script cannot be fixed automatically (e.g. a missing upstream dependency, an ambiguous API change), leave it unchanged and list it in your PR description under a "Could not update" section with the reason.
+          7. After all scripts pass, regenerate notebooks by running:
+             \`\`\`
+             pip install ipynb-py-convert
+             git clone https://github.com/Jammy2211/PyAutoBuild.git ../PyAutoBuild
+             PYTHONPATH=../PyAutoBuild/autobuild python3 ../PyAutoBuild/autobuild/generate.py autofit
+             \`\`\`
+          8. Commit the regenerated notebooks alongside the script changes.
 
           ### Branch
           Use branch name: \`${WORKSPACE_BRANCH}\`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,16 @@ When assigned an issue titled `[API Update]`:
 5. Read any failure logs in `failed/` and fix the affected scripts.
 6. Repeat steps 4–5 until the suite is clean.
 7. If a script cannot be fixed (ambiguous change, missing dependency), leave it unchanged and list it in the PR description under **"Could not update"** with the reason.
+8. After all scripts pass, regenerate the notebooks from the updated scripts (see below).
+
+## Generating Notebooks
+
+Notebooks in `notebooks/` are generated from `scripts/` using the PyAutoBuild tool. After updating scripts, regenerate all notebooks:
+
+```bash
+pip install ipynb-py-convert
+git clone https://github.com/Jammy2211/PyAutoBuild.git ../PyAutoBuild
+PYTHONPATH=../PyAutoBuild/autobuild python3 ../PyAutoBuild/autobuild/generate.py autofit
+```
+
+This must be run from the workspace root directory. It converts every `.py` in `scripts/` to a `.ipynb` in `notebooks/`. Commit the regenerated notebooks alongside the script changes.


### PR DESCRIPTION
## Summary
- Updates `AGENTS.md`, `.github/copilot-instructions.md`, and the issue template in `api-update.yml`
- After all scripts pass testing, Copilot now clones PyAutoBuild and runs `generate.py autofit` to regenerate notebooks
- Notebooks are committed alongside script changes in the PR

## Test plan
- [ ] Merge, then trigger the API Update workflow manually to verify the issue includes the notebook generation instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)