### PR TITLE
fix: unset PYAUTOFIT_TEST_MODE for EmceePlotter/ZeusPlotter

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -18,4 +18,10 @@ defaults:
   NUMBA_CACHE_DIR: "/tmp/numba_cache"   # Writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"       # Writable config dir for matplotlib
 
-overrides: []
+overrides:
+  # Plotter scripts need the real search to run so `result.search_internal` is
+  # populated — bypass mode skips the sampler and returns None.
+  - pattern: "plot/EmceePlotter"
+    unset: [PYAUTOFIT_TEST_MODE]
+  - pattern: "plot/ZeusPlotter"
+    unset: [PYAUTOFIT_TEST_MODE]


### PR DESCRIPTION
## Summary
- Category F fix: plotter scripts accessed `result.search_internal` which is `None` in bypass mode (`PYAUTOFIT_TEST_MODE=2`) because the sampler is skipped.
- Added `env_vars.yaml` overrides so the real Emcee/Zeus search runs for these two scripts.

## Test plan
- [x] `python scripts/plot/EmceePlotter.py` with TEST_MODE unset — EXIT=0, walker trajectory plots render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)