### PR TITLE
refactor: rename env vars to PYAUTO_* prefix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ You are working on the **autofit_workspace**, a tutorial/example repository for 
 
 ## Testing
 
-`run_scripts.sh` sets `PYAUTOFIT_TEST_MODE=1` automatically. Every script should pass in this mode. A script that fails in test mode indicates a real problem (broken import, wrong function name, etc.).
+`run_scripts.sh` sets `PYAUTO_TEST_MODE=1` automatically. Every script should pass in this mode. A script that fails in test mode indicates a real problem (broken import, wrong function name, etc.).
 
 ## Notebook Generation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ python scripts/overview/overview_1_the_basics.py
 
 ## Testing
 
-Set `PYAUTOFIT_TEST_MODE=1` so non-linear searches skip actual sampling (fast test run).
+Set `PYAUTO_TEST_MODE=1` so non-linear searches skip actual sampling (fast test run).
 
 Run all scripts:
 
@@ -28,7 +28,7 @@ Run all scripts:
 bash run_scripts.sh
 ```
 
-This sets `PYAUTOFIT_TEST_MODE=1` automatically, runs every script in `scripts/`, and reports pass/fail/skipped counts. Failure logs are written to `failed/<relative_path>.log`.
+This sets `PYAUTO_TEST_MODE=1` automatically, runs every script in `scripts/`, and reports pass/fail/skipped counts. Failure logs are written to `failed/<relative_path>.log`.
 
 ### Script ordering
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ python scripts/searches/nest/dynesty/uniform.py
 
 ## Testing All Scripts
 
-`PYAUTOFIT_TEST_MODE=1` causes non-linear searches to skip actual sampling (fast test run).
+`PYAUTO_TEST_MODE=1` causes non-linear searches to skip actual sampling (fast test run).
 
 Run all scripts using the provided runner:
 
@@ -52,7 +52,7 @@ bash run_scripts.sh
 To run a single script in test mode:
 
 ```
-PYAUTOFIT_TEST_MODE=1 python3 scripts/overview/overview_1_the_basics.py
+PYAUTO_TEST_MODE=1 python3 scripts/overview/overview_1_the_basics.py
 ```
 
 After a full run, inspect failures:

--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -9,8 +9,11 @@
 #   - Patterns without '/' match the file stem exactly
 
 defaults:
-  PYAUTOFIT_TEST_MODE: "2"              # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
-  PYAUTO_WORKSPACE_SMALL_DATASETS: "1"  # Cap grids/masks to 15x15, reduce MGE gaussians
+  PYAUTO_TEST_MODE: "2"                 # 0=normal, 1=reduced iterations, 2=skip sampler (fastest)
+  PYAUTO_SKIP_FIT_OUTPUT: "1"           # Skip pre/post-fit I/O, VRAM profiling, result text
+  PYAUTO_SKIP_VISUALIZATION: "1"        # Skip fit visualization and plotting
+  PYAUTO_SKIP_CHECKS: "1"              # Skip mesh validation, position checks, weight thresholds
+  PYAUTO_SMALL_DATASETS: "1"           # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"              # Force use_jax=False, avoid JIT compilation overhead
   PYAUTO_FAST_PLOTS: "1"               # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"               # Enable 64-bit precision in JAX
@@ -21,6 +24,6 @@ overrides:
   # Plotter scripts need the real search to run so `result.search_internal` is
   # populated — bypass mode skips the sampler and returns None.
   - pattern: "plot/EmceePlotter"
-    unset: [PYAUTOFIT_TEST_MODE]
+    unset: [PYAUTO_TEST_MODE, PYAUTO_SKIP_FIT_OUTPUT]
   - pattern: "plot/ZeusPlotter"
-    unset: [PYAUTOFIT_TEST_MODE]
+    unset: [PYAUTO_TEST_MODE, PYAUTO_SKIP_FIT_OUTPUT]

--- a/run_scripts.sh
+++ b/run_scripts.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Run all scripts in scripts/ with PYAUTOFIT_TEST_MODE=1.
+# Run all scripts in scripts/ with PYAUTO_TEST_MODE=1.
 #
 # Rules:
 #   - start_here.py in a folder runs before all other scripts and subfolders in that folder
@@ -12,8 +12,11 @@ FAILED_DIR="$SCRIPT_DIR/failed"
 NO_RUN_YAML="$SCRIPT_DIR/../PyAutoBuild/autobuild/config/no_run.yaml"
 PROJECT_KEY="autofit"
 
-export PYAUTOFIT_TEST_MODE=1
-export PYAUTO_WORKSPACE_SMALL_DATASETS=1
+export PYAUTO_TEST_MODE=1
+export PYAUTO_SKIP_FIT_OUTPUT=1
+export PYAUTO_SKIP_VISUALIZATION=1
+export PYAUTO_SKIP_CHECKS=1
+export PYAUTO_SMALL_DATASETS=1
 export PYAUTO_FAST_PLOTS=1
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Update env_vars.yaml, run_scripts.sh, and documentation to use the new unified `PYAUTO_*` environment variable names introduced by the upstream library refactor.

## Scripts Changed
- `config/build/env_vars.yaml` — renamed vars, added `PYAUTO_SKIP_FIT_OUTPUT`, `PYAUTO_SKIP_VISUALIZATION`, `PYAUTO_SKIP_CHECKS`
- `run_scripts.sh` — renamed exports to new var names
- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` — updated documentation

## Upstream PRs
- https://github.com/PyAutoLabs/PyAutoConf/pull/86
- https://github.com/PyAutoLabs/PyAutoFit/pull/1195

## Test Plan
- [x] Smoke tests pass (6/7 — 1 pre-existing failure in cookbooks/samples.py, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)