### PR TITLE
Drop Binder URLs, pin Colab URLs to workspace tag 2026.4.13.6

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -1,0 +1,23 @@
+name: URL Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  url_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Run url_check.sh
+        run: bash PyAutoBuild/autobuild/url_check.sh repo

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,17 @@
 PyAutoFit Workspace
 ====================
 
-.. |binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/HEAD
+.. |colab| image:: https://colab.research.google.com/assets/colab-badge.svg
+   :target: https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/start_here.ipynb
 
 .. |JOSS| image:: https://joss.theoj.org/papers/10.21105/joss.02550/status.svg
    :target: https://doi.org/10.21105/joss.02550
 
-|binder| |JOSS|
+|colab| |JOSS|
 
 `Installation Guide <https://pyautofit.readthedocs.io/en/latest/installation/overview.html>`_ |
 `readthedocs <https://pyautofit.readthedocs.io/en/latest/index.html>`_ |
-`Introduction on Binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/overview/overview_1_the_basics.ipynb>`_ |
+`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/overview/overview_1_the_basics.ipynb>`_ |
 `HowToFit <https://pyautofit.readthedocs.io/en/latest/howtofit/howtofit.html>`_
 
 Welcome to the **PyAutoFit** Workspace! 
@@ -23,7 +23,7 @@ You can get set up on your personal computer by following the installation guide
 our `readthedocs <https://pyautofit.readthedocs.io/>`_.
 
 Alternatively, you can try **PyAutoFit** out in a web browser by going to the `autofit workspace
-Binder <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/overview/overview_1_the_basics.ipynb>`_.
+Colab <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/overview/overview_1_the_basics.ipynb>`_.
 
 Where To Go?
 ------------

--- a/notebooks/howtofit/chapter_1_introduction/README.rst
+++ b/notebooks/howtofit/chapter_1_introduction/README.rst
@@ -1,24 +1,24 @@
 In chapter 1, we introduce you to the **PyAutoFit** and describe how to set up your own model, fit it to data via
 a non-linear search and inspect and interpret the results.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 Files
 -----
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
+`Tutorial 1: Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
 - What probabilistic models are and how to compose them using PyAutoFit.
 
-`Tutorial 2: Fitting Data <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
+`Tutorial 2: Fitting Data <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
 - Fitting a model with an input set of parameters to data and quantifying the goodness of fit.
 
-`Tutorial 3: Non Linear Search <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
+`Tutorial 3: Non Linear Search <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
 - Searching non-linear parameter spaces to find the best-fit model.
 
-`Tutorial 4: Complex Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
+`Tutorial 4: Complex Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
 - Composing and fitting more complex models in a scalable and extensible way.
 
-`Tutorial 5: Results and Samples <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
+`Tutorial 5: Results and Samples <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
 - Interpreting model-fit results and using the samples for scientific analysis.

--- a/notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb
+++ b/notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb
@@ -94,7 +94,7 @@
       "source": [
         "__Paths__\n",
         "\n",
-        "PyAutoFit assumes the current working directory is /path/to/autofit_workspace/ on your hard-disk (or in Binder). \n",
+        "PyAutoFit assumes the current working directory is /path/to/autofit_workspace/ on your hard-disk (or in Colab). \n",
         "This setup allows PyAutoFit to:\n",
         "\n",
         "- Load configuration settings from config files in the autofit_workspace/config folder.\n",

--- a/notebooks/howtofit/chapter_3_graphical_models/README.rst
+++ b/notebooks/howtofit/chapter_3_graphical_models/README.rst
@@ -2,24 +2,24 @@ In this chapter, we take you through how to compose and fit graphical models in 
 simultaneously fit many datasets with a model that has 'local' parameters specific to each individual dataset
 and 'global' parameters that fit for global trends across the whole dataset.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 Files
 -----
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Individual Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
+`Tutorial 1: Individual Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
 - Inferring global parameters from a dataset by fitting the model to each individual dataset one-by-one.
 
-`Tutorial 2: Graphical Model <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
+`Tutorial 2: Graphical Model <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
 - Fitting the dataset with a graphical model that fits all datasets simultaneously to infer the global parameters.
 
-`Tutorial 3: Graphical Benefits <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
+`Tutorial 3: Graphical Benefits <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
 - Illustrating the benefits of graphical modeling over fitting individual datasets one-by-one.
 
-`Tutorial 4: Hierarchical Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
+`Tutorial 4: Hierarchical Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
 - Fitting hierarchical models using the graphical modeling framework.
 
-`Tutorial 5: Expectation Propagation <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
+`Tutorial 5: Expectation Propagation <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
 - Scaling graphical models up to fit extremely large datasets using Expectation Propagation (EP).

--- a/scripts/howtofit/chapter_1_introduction/README.rst
+++ b/scripts/howtofit/chapter_1_introduction/README.rst
@@ -1,24 +1,24 @@
 In chapter 1, we introduce you to the **PyAutoFit** and describe how to set up your own model, fit it to data via
 a non-linear search and inspect and interpret the results.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 Files
 -----
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
+`Tutorial 1: Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_1_models.ipynb>`_
 - What probabilistic models are and how to compose them using PyAutoFit.
 
-`Tutorial 2: Fitting Data <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
+`Tutorial 2: Fitting Data <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_2_fitting_data.ipynb>`_
 - Fitting a model with an input set of parameters to data and quantifying the goodness of fit.
 
-`Tutorial 3: Non Linear Search <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
+`Tutorial 3: Non Linear Search <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_3_non_linear_search.ipynb>`_
 - Searching non-linear parameter spaces to find the best-fit model.
 
-`Tutorial 4: Complex Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
+`Tutorial 4: Complex Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_4_complex_models.ipynb>`_
 - Composing and fitting more complex models in a scalable and extensible way.
 
-`Tutorial 5: Results and Samples <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
+`Tutorial 5: Results and Samples <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_1_introduction/tutorial_5_results_and_samples.ipynb>`_
 - Interpreting model-fit results and using the samples for scientific analysis.

--- a/scripts/howtofit/chapter_1_introduction/tutorial_1_models.py
+++ b/scripts/howtofit/chapter_1_introduction/tutorial_1_models.py
@@ -78,7 +78,7 @@ import autofit as af
 """
 __Paths__
 
-PyAutoFit assumes the current working directory is /path/to/autofit_workspace/ on your hard-disk (or in Binder). 
+PyAutoFit assumes the current working directory is /path/to/autofit_workspace/ on your hard-disk (or in Colab). 
 This setup allows PyAutoFit to:
 
 - Load configuration settings from config files in the autofit_workspace/config folder.

--- a/scripts/howtofit/chapter_3_graphical_models/README.rst
+++ b/scripts/howtofit/chapter_3_graphical_models/README.rst
@@ -2,24 +2,24 @@ In this chapter, we take you through how to compose and fit graphical models in 
 simultaneously fit many datasets with a model that has 'local' parameters specific to each individual dataset
 and 'global' parameters that fit for global trends across the whole dataset.
 
-**Binder** links to every tutorial are included.
+**Colab** links to every tutorial are included.
 
 Files
 -----
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Individual Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
+`Tutorial 1: Individual Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_1_individual_models.ipynb>`_
 - Inferring global parameters from a dataset by fitting the model to each individual dataset one-by-one.
 
-`Tutorial 2: Graphical Model <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
+`Tutorial 2: Graphical Model <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_2_graphical_model.ipynb>`_
 - Fitting the dataset with a graphical model that fits all datasets simultaneously to infer the global parameters.
 
-`Tutorial 3: Graphical Benefits <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
+`Tutorial 3: Graphical Benefits <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_3_graphical_benefits.ipynb>`_
 - Illustrating the benefits of graphical modeling over fitting individual datasets one-by-one.
 
-`Tutorial 4: Hierarchical Models <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
+`Tutorial 4: Hierarchical Models <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_4_hierarchical_models.ipynb>`_
 - Fitting hierarchical models using the graphical modeling framework.
 
-`Tutorial 5: Expectation Propagation <https://mybinder.org/v2/gh/Jammy2211/autofit_workspace/release?filepath=notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
+`Tutorial 5: Expectation Propagation <https://colab.research.google.com/github/PyAutoLabs/autofit_workspace/blob/2026.4.13.6/notebooks/howtofit/chapter_graphical_models/tutorial_5_expectation_propagation.ipynb>`_
 - Scaling graphical models up to fit extremely large datasets using Expectation Propagation (EP).


### PR DESCRIPTION
## Summary

Drop all `mybinder.org` URLs in favour of Google Colab. Pin every Colab URL to the
date-based workspace tag (currently `2026.4.13.6`) so links stay aligned with the
PyPI-released library that users will have installed. Rewrite the GitHub owner
from `Jammy2211` to `PyAutoLabs`.

## What changed

- **URL rewrites** across `*.rst`, `*.md`, `*.ipynb`, `*.py`:
  - `mybinder.org/v2/gh/Jammy2211/<ws>/release?filepath=<path>` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
  - `mybinder.org/v2/gh/Jammy2211/<ws>/HEAD` → `colab.research.google.com/github/PyAutoLabs/<ws>/blob/2026.4.13.6/start_here.ipynb`
  - `colab…/Jammy2211/<ws>/blob/release/<path>` → `colab…/PyAutoLabs/<ws>/blob/2026.4.13.6/<path>`
- **Badge swap**: Binder badge images replaced with the official Colab badge
  (`colab-badge.svg`); RST `|binder|` substitution renamed to `|colab|`.
- **Prose cleanup**: every "Binder" link caption / sentence rewritten to "Colab"
  (case-preserving) so link text matches link target.

## Release-pipeline integration

The release workflow in PyAutoBuild (#49, merged) now invokes
`bump_colab_urls.sh <new-tag>` against this repo on every release, so the pinned
tag advances automatically. No manual maintenance is required after this PR.

## Regression guard

Adds `.github/workflows/url_check.yml` which runs PyAutoBuild's
`autobuild/url_check.sh` on every push and pull request. Re-introducing any
`mybinder.org` URL, `Jammy2211/` Colab owner, or `/blob/release/` Colab ref will
fail CI.

## Test Plan
- [ ] `url_check.yml` workflow passes on this PR
- [ ] Spot-check a Colab URL by clicking through to confirm the notebook loads at the pinned tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
