### PR TITLE
ci: add smoke tests workflow, re-enable mle.py search

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -1,0 +1,112 @@
+"""
+Run the workspace smoke test suite.
+
+Reads `smoke_tests.txt` from the workspace root and `config/build/env_vars.yaml`
+for per-script env var overrides, then runs each listed script with the
+appropriate environment. Continues through failures and exits non-zero
+if any script failed.
+
+Mirrors the logic of the `/smoke-test` skill so CI and local runs stay
+in sync.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+
+WORKSPACE = Path(__file__).resolve().parents[2]
+SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
+ENV_VARS_FILE = WORKSPACE / "config" / "build" / "env_vars.yaml"
+SCRIPTS_DIR = WORKSPACE / "scripts"
+
+
+def load_smoke_scripts() -> list[str]:
+    scripts: list[str] = []
+    for line in SMOKE_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        scripts.append(line)
+    return scripts
+
+
+def load_env_config() -> dict:
+    if not ENV_VARS_FILE.exists():
+        return {"defaults": {}, "overrides": []}
+    return yaml.safe_load(ENV_VARS_FILE.read_text()) or {}
+
+
+def pattern_matches(pattern: str, script_path: str) -> bool:
+    if "/" in pattern:
+        return pattern in script_path
+    return Path(script_path).stem == pattern
+
+
+def build_env(script_rel: str, cfg: dict) -> dict:
+    env = os.environ.copy()
+    defaults = cfg.get("defaults") or {}
+    env.update({k: str(v) for k, v in defaults.items()})
+    for override in cfg.get("overrides") or []:
+        if pattern_matches(override["pattern"], script_rel):
+            for key in override.get("unset", []):
+                env.pop(key, None)
+            for key, val in (override.get("set") or {}).items():
+                env[key] = str(val)
+    return env
+
+
+def run_one(script_rel: str, cfg: dict) -> tuple[str, int, float, str]:
+    env = build_env(script_rel, cfg)
+    script_path = SCRIPTS_DIR / script_rel
+    t0 = time.time()
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=str(WORKSPACE),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    elapsed = time.time() - t0
+    output = result.stdout + result.stderr
+    return script_rel, result.returncode, elapsed, output
+
+
+def main() -> int:
+    if not SMOKE_FILE.exists():
+        print(f"ERROR: no smoke_tests.txt at {SMOKE_FILE}", file=sys.stderr)
+        return 1
+    scripts = load_smoke_scripts()
+    if not scripts:
+        print("No smoke test scripts listed.")
+        return 0
+    cfg = load_env_config()
+
+    print(f"Running {len(scripts)} smoke test script(s) from {SMOKE_FILE.name}\n")
+    failures: list[tuple[str, int, str]] = []
+    for script_rel in scripts:
+        print(f"::group::{script_rel}")
+        name, rc, elapsed, output = run_one(script_rel, cfg)
+        print(output, end="")
+        status = "PASS" if rc == 0 else f"FAIL (exit {rc})"
+        print(f"\n[{status}] {name} — {elapsed:.1f}s")
+        print("::endgroup::")
+        if rc != 0:
+            failures.append((name, rc, output))
+
+    total = len(scripts)
+    passed = total - len(failures)
+    print(f"\n=== Smoke test summary: {passed}/{total} passed ===")
+    for name, rc, _ in failures:
+        print(f"  FAIL  {name}  (exit {rc})")
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,0 +1,83 @@
+name: Smoke Tests
+
+on: [push, pull_request]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+    - name: Checkout PyAutoConf
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoConf
+        path: PyAutoConf
+    - name: Checkout PyAutoFit
+      uses: actions/checkout@v4
+      with:
+        repository: PyAutoLabs/PyAutoFit
+        path: PyAutoFit
+    - name: Checkout workspace
+      uses: actions/checkout@v4
+      with:
+        path: workspace
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Extract branch name
+      id: extract_branch
+      shell: bash
+      run: |
+        cd workspace
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
+    - name: Match library branches
+      shell: bash
+      run: |
+        BRANCH="${{ steps.extract_branch.outputs.branch }}"
+        for PKG in PyAutoConf PyAutoFit; do
+          pushd "$PKG"
+          if [[ -n "$(git ls-remote --heads origin "$BRANCH")" ]]; then
+            echo "Branch $BRANCH exists in $PKG — checking out"
+            git fetch origin "$BRANCH"
+            git checkout "$BRANCH"
+          else
+            echo "Branch $BRANCH not in $PKG — staying on main"
+          fi
+          popd
+        done
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip setuptools wheel
+        pip install pyyaml
+        if [ "${{ matrix.python-version }}" = "3.12" ]; then
+          pip install ./PyAutoConf "./PyAutoFit[optional]"
+        else
+          pip install ./PyAutoConf ./PyAutoFit
+        fi
+        pip install nautilus-sampler
+    - name: Prepare cache dirs
+      run: |
+        mkdir -p /tmp/numba_cache /tmp/matplotlib
+    - name: Run smoke tests
+      env:
+        JAX_ENABLE_X64: "True"
+        NUMBA_CACHE_DIR: /tmp/numba_cache
+        MPLCONFIGDIR: /tmp/matplotlib
+      run: |
+        cd workspace
+        python .github/scripts/run_smoke.py
+    - name: Slack notify on failure
+      if: ${{ failure() }}
+      uses: slackapi/slack-github-action@v1.21.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        channel-id: C03S98FEDK2
+        payload: |
+          {
+            "text": "${{ github.repository }}/${{ github.ref_name }} smoke tests (Python ${{ matrix.python-version }}) ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }

--- a/smoke_tests.txt
+++ b/smoke_tests.txt
@@ -1,7 +1,7 @@
 overview/overview_1_the_basics.py
 searches/mcmc.py
 searches/nest.py
-# searches/mle.py  # disabled: bypass mode triggers search_internal cleanup error (rhayes777/PyAutoFit#1179)
+searches/mle.py
 cookbooks/model.py
 cookbooks/result.py
 cookbooks/samples.py


### PR DESCRIPTION
## Summary
- **Add `.github/workflows/smoke_tests.yml`** — new GitHub Actions workflow mirroring `autofit_workspace_test`'s smoke setup (checkout PyAutoConf + PyAutoFit, match branch names, pip install, run `.github/scripts/run_smoke.py`, Slack-notify on failure). Closes the gap where `smoke_tests.txt` + `config/build/{env_vars,no_run}.yaml` existed but nothing ran them in CI.
- **Add `.github/scripts/run_smoke.py`** — runner copied from `autofit_workspace_test`; reads the smoke list + env var overrides and runs each script with the right environment.
- **Re-enable `searches/mle.py`** — was disabled pending `rhayes777/PyAutoFit#1179` (bypass-mode cleanup error); that issue closed 2026-04-06 and the script now passes under `PYAUTO_TEST_MODE=2`.

## Test plan
- [x] `python .github/scripts/run_smoke.py` locally with fresh output → **7/7 passed** (overview + mcmc + nest + mle + model + result + samples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)