### PR TITLE
feat: workspace-owned build configs (copy_files, visualise_notebooks)

### DIFF
--- a/config/build/copy_files.yaml
+++ b/config/build/copy_files.yaml
@@ -1,0 +1,13 @@
+# Files copied as-is into notebooks/ instead of being converted from
+# scripts/. Used by PyAutoBuild's generate.py during the pre-build step.
+#
+# Format: flat list of script paths relative to the workspace root.
+# Patterns matched by suffix — any file path ending with one of these
+# entries is treated as copy-only.
+#
+# This file overrides PyAutoBuild/autobuild/config/copy_files.yaml for
+# this workspace. Add or remove entries here, not there.
+
+- howtofit/chapter_1_introduction/gaussian.py
+- howtofit/chapter_1_introduction/profiles.py
+- howtofit/chapter_database/profiles.py

--- a/config/build/visualise_notebooks.yaml
+++ b/config/build/visualise_notebooks.yaml
@@ -1,0 +1,10 @@
+# Notebook stems that should run when PyAutoBuild's generate / run pipeline
+# is invoked with --visualise. Used to refresh notebook output cells in main.
+#
+# Format: flat list of notebook stems (no extension, no path).
+# An empty list means no notebooks need re-visualisation in this workspace.
+#
+# This file overrides PyAutoBuild/autobuild/config/visualise_notebooks.yaml
+# for this workspace. Add or remove entries here, not there.
+
+[]


### PR DESCRIPTION
## Summary

Migrates per-project build config from `PyAutoBuild/autobuild/config/` down to this workspace's `config/build/` directory as flat-list YAML files. PyAutoBuild's `run.py` / `run_python.py` / `generate.py` now prefer the workspace files over their own keyed-dict copies — so this workspace is the single source of truth for what scripts to skip, copy as-is, or visualise.

Companion changes ship together on `feature/autobuild-release-prep`:
- PyAutoBuild — code that reads the new workspace files, plus persistent timestamped run results
- autofit_workspace, autogalaxy_workspace, autolens_workspace, *_test — same migration
- PyAutoPrompt — new `/pyauto-status-full` skill

## Test plan
- [x] PyAutoBuild's new `tests/test_workspace_config_precedence.py` passes
- [x] full release-prep run via `python autobuild/run_all.py` reads these files correctly