### PR TITLE
feat: embed workspace_version in config + drop welcome.py duplicate check

### DIFF
--- a/config/general.yaml
+++ b/config/general.yaml
@@ -30,3 +30,6 @@ test:
   lh_timeout_seconds:               # If a float is input, the log_likelihood_function call is timed out after this many seconds, to diagnose infinite loops. Default is None, meaning no timeout.
   preloads_check_threshold: 1.0     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit.
   parallel_profile: false
+version:
+  workspace_version: 2026.4.13.6    # Pinned by the release pipeline; must match the installed library version.
+  workspace_version_check: True     # If False, bypass the workspace/library version check. Set to False on `main`-branch clones — `main` updates faster than releases, so mismatches are expected and not actionable.

--- a/welcome.py
+++ b/welcome.py
@@ -1,7 +1,4 @@
 import autofit as af
-from autoconf import check_version
-
-check_version(af.__version__)
 
 input(
     "\n"


### PR DESCRIPTION
## Summary
Embed `version.workspace_version: 2026.4.13.6` and a user-facing `version.workspace_version_check: True` override flag in `config/general.yaml`, so the new config-aware `autoconf.workspace.check_version` (PyAutoLabs/PyAutoConf#101, now called from every `import autofit/autogalaxy/autolens`) can resolve the workspace version from a canonical source that travels with the user's config directory. The `version.txt` legacy fallback continues to work.

Also drop the now-redundant `check_version(<lib>.__version__)` call from `welcome.py` — the libraries do the check on import, so calling it again from `welcome.py` was duplicate work that fired only when users explicitly ran `welcome.py` (which most don't after the first time).

Setting `workspace_version_check: False` is the recommended bypass for users on `main`-branch workspace clones, where `main` updates faster than library releases and mismatches are expected.

## Scripts Changed
- `config/general.yaml` — add a `version:` block with `workspace_version: 2026.4.13.6` and `workspace_version_check: True`
- `welcome.py` — remove the redundant `from autoconf import check_version` import and the `check_version(<lib>.__version__)` call (libraries now run the check on import via PyAutoFit/Galaxy/Lens `__init__.py`)

## Upstream PR
- PyAutoLabs/PyAutoConf#101 — config-aware `check_version` (core change)
- PyAutoLabs/PyAutoFit#1241, PyAutoLabs/PyAutoGalaxy#380, PyAutoLabs/PyAutoLens#484 — call `check_version` on library import
- PyAutoLabs/PyAutoBuild#70 — release pipeline writes the new YAML key; `verify_workspace_versions.sh` reads it

## Test Plan
- [x] `python -c "import <lib>"` from this workspace runs silently (no warning, no error — version key matches installed library)
- [x] `bash PyAutoBuild/verify_workspace_versions.sh` reports this workspace as `ok`
- [ ] CI smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)