### PR TITLE
Fix graphical_models.py auto-sim to call simulators_sample.py

### DIFF
--- a/scripts/features/graphical_models.py
+++ b/scripts/features/graphical_models.py
@@ -71,13 +71,13 @@ If the dataset does not already exist on your system, it will be created by runn
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
 if not path.exists(
-    path.join("dataset", "example_1d", "gaussian_x1__low_snr", "dataset_0")
+    path.join("dataset", "example_1d", "gaussian_x1__low_snr", "dataset_0", "data.json")
 ):
     import subprocess
     import sys
 
     subprocess.run(
-        [sys.executable, "scripts/simulators/simulators.py"],
+        [sys.executable, "scripts/simulators/simulators_sample.py"],
         check=True,
     )
 


### PR DESCRIPTION
## Summary
- Fix the auto-simulation block in `graphical_models.py` to call the correct simulator script
- `simulators.py` emits `gaussian_x1` (no SNR suffix); `simulators_sample.py` is the producer for `gaussian_x1__low_snr` (50 datasets) and `gaussian_x1__hierarchical` (10 datasets)
- Also tighten the existence check from `dataset_0` (directory) to `dataset_0/data.json` (file), so an empty stub directory still triggers a re-sim

## Scripts Changed
- `scripts/features/graphical_models.py` — auto-sim block

## Why now
Surfaced by triage Cluster F item 7 — `graphical_models.py` failed with `FileNotFoundError: dataset/example_1d/gaussian_x1__low_snr/dataset_0/data.json` in the release-prep run (2026-04-29). The auto-sim block existed but called the wrong simulator, so it never produced the missing file.

## Test plan
- [x] `python scripts/features/graphical_models.py` runs to completion under `PYAUTO_TEST_MODE=2` (verified pre-shipping by Opus)
- [x] Workspace smoke tests (7/7) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)