### PR TITLE
docs: render __Contents__ blocks as Markdown lists

### DIFF
--- a/scripts/cookbooks/model.py
+++ b/scripts/cookbooks/model.py
@@ -9,7 +9,7 @@ This cookbook provides an overview of basic model composition tools.
 
 __Contents__
 
-**Models:**
+- **Models:**
 
 If first describes how to use the `af.Model` object to define models with a single model component from single
 Python classes, with the following sections:


### PR DESCRIPTION
## Summary

Convert `__Contents__` blocks at the top of workspace tutorial scripts' module docstrings from plain `**Section:**` lines into Markdown list bullets (`- **Section:**`).

Without bullet markers, GitHub and JupyterLab collapse the contents block into one continuous paragraph in the generated notebook's first markdown cell. Prefixing each entry with `- ` makes it render as a list. Text-only change inside top-level module docstrings.

## Scripts Changed

1 script — `scripts/cookbooks/model.py` had a single un-bulleted `**Models:**` heading inside its `__Contents__` block. Most of this repo's tutorial scripts were already bulleted (28 files); only this one needed the fix.

## Test Plan
- [ ] Smoke tests pass

Refs PyAutoLabs/autolens_workspace#138

🤖 Generated with [Claude Code](https://claude.com/claude-code)