### PR TITLE
Disable model.graph output by default

### DIFF
--- a/config/output.yaml
+++ b/config/output.yaml
@@ -100,3 +100,5 @@ data: true # `data.json`: The value of every data point in the data.
 noise_map: true # `noise_map.json`: The value of every RMS noise map value.
 
 search_log: true # `search.log`: logging produced whilst running the fit method
+
+model_graph: false # `model.graph`: graphical-model factor graph summary. Only meaningful for graphical models (autofit.graphical); empty for ordinary PriorModel/Collection fits, so disabled by default.


### PR DESCRIPTION
## Summary

Mirror the new `model_graph` flag from PyAutoFit PR #1264 in this workspace's `config/output.yaml`, defaulting to `false`. The library now gates the `model.graph` file behind `should_output("model_graph")`, but without an explicit entry here the workspace's `default: true` would still resolve to "write the file" — and the empty `model.graph` would keep being created for every non-graphical fit. Setting `model_graph: false` here makes the disable end-to-end for workspace users.

## Scripts Changed

- None — config-only change to `config/output.yaml`.

## Upstream PR

https://github.com/PyAutoLabs/PyAutoFit/pull/1264

## Test Plan

- [ ] Smoke tests pass.
- [ ] Run a small fit and confirm `model.graph` is NOT created in the output folder.
- [ ] `model.info` and `metadata` files are still produced as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)