### PR TITLE
chore(scripts): Phase 3 use_jax=True consistency in features/search_chaining

### DIFF
--- a/scripts/features/search_chaining.py
+++ b/scripts/features/search_chaining.py
@@ -142,7 +142,7 @@ It fits the data as the sum of as many `Gaussian`'s as are in the model.
 To better fit the left gaussian, we remove all data points in the right-half of the data. Note that for more 
 computationally demanding model-fitting problems this would give a significant speed-up in log likelihood function.
 """
-analysis_1 = af.ex.Analysis(data=data[0:50], noise_map=noise_map[0:50])
+analysis_1 = af.ex.Analysis(data=data[0:50], noise_map=noise_map[0:50], use_jax=True)
 
 """
 __Model__
@@ -210,7 +210,7 @@ We now repeat the above process for the right `Gaussian`.
 We could remove the data on the left like we did the `Gaussian` above. However, we are instead going to fit the full 
 dataset.
 """
-analysis_2 = af.ex.Analysis(data=data, noise_map=noise_map)
+analysis_2 = af.ex.Analysis(data=data, noise_map=noise_map, use_jax=True)
 
 """
 __Model__
@@ -307,7 +307,7 @@ print(model_3.info)
 """
 We now perform the search.
 """
-analysis_3 = af.ex.Analysis(data=data, noise_map=noise_map)
+analysis_3 = af.ex.Analysis(data=data, noise_map=noise_map, use_jax=True)
 
 search_3 = af.DynestyStatic(
     name="search[3]__both_gaussians",
@@ -462,7 +462,7 @@ noise_map = af.util.numpy_array_from_json(
     file_path=path.join(dataset_path, "noise_map.json")
 )
 
-analysis = af.ex.Analysis(data=data, noise_map=noise_map)
+analysis = af.ex.Analysis(data=data, noise_map=noise_map, use_jax=True)
 
 dynesty = af.DynestyStatic(name="cookbook_5_model_linking", nlive=50, sample="rwalk")
 


### PR DESCRIPTION
## Summary
Phase 3 of `z_features/jax_visualization.md` (now archived). Phase 2 (PyAutoFit #1278) made `use_jax=True` sufficient. autofit_workspace tutorials use a toy 1D Gaussian where JIT compile overhead dominates — most tutorials intentionally opt out, with `searches/mcmc.py` / `searches/nest.py` / `features/search_grid_search.py` as the existing exceptions. The 2026-05-16 audit flagged `features/search_chaining.py` as an inconsistency: it chained multiple `af.ex.Analysis` instances but none used `use_jax=True`, while its sibling `features/search_grid_search.py` did.

## Scripts Changed

- `scripts/features/search_chaining.py` — added `use_jax=True` to all 4 `af.ex.Analysis(...)` calls so the chained pipeline runs the same JAX path as the grid-search sibling

## Skip list — files INTENTIONALLY not edited

- `searches/mle.py` — explicit `use_jax=False` (LBFGS / gradient-based MLE incompatible with JAX tracing)
- `cookbooks/*` — API-reference demos using minimal toy models; JIT overhead would obscure the tutorial subject
- `overview/*` — introductory tutorials, no benefit
- `features/{graphical_models,sensitivity_mapping,model_comparison,interpolate}.py` — feature-specific demos using toy data

## Roadmap context
Phases 0-2 shipped May 2026. Phase 4 (subprocess visualization) and Phase 5 (live Colab/Jupyter cell) remain explicit stubs.

## Test Plan
- [x] Smoke tests: 7/7 pass on `autofit_workspace` (20/20 across the 3 workspaces in this sweep).
- [x] `PYAUTO_DISABLE_JAX=1` in smoke defaults forces `use_jax=False`, so smoke verifies kwarg parsing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)