### PR TITLE
ci(smoke): install nss extras + handley-lab/blackjax fork for nest.py

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -64,6 +64,12 @@ jobs:
           pip install ./PyAutoConf ./PyAutoFit
         fi
         pip install nautilus-sampler
+        # NSS sampler — searches/nest.py exercises `af.NSS`, which needs the
+        # `[nss]` extra plus two manually-installed git pins. The SHAs match
+        # PyAutoFit/pyproject.toml `[project.optional-dependencies] nss`.
+        pip install "./PyAutoFit[nss]"
+        pip install "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5"
+        pip install "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
         pip install jupyter nbconvert ipynb-py-convert
     - name: Prepare cache dirs
       run: |


### PR DESCRIPTION
## Summary

scripts/searches/nest.py was extended on 2026-05-27 to include an `af.NSS` example. The smoke CI install step was never updated to install the matching dependencies, so the script fails on every CI run.

Adds three install lines:

- `pip install "./PyAutoFit[nss]"` — pulls in `fastprogress<1.1`
- `pip install "blackjax @ git+https://.../handley-lab/blackjax.git@ef45acd2..."` — the BlackJAX fork carrying `blackjax.ns.adaptive.init`
- `pip install "nss @ git+https://.../yallup/nss.git@69159b0f..."` — Nested Slice Sampling on top

SHAs match PyAutoFit's pyproject.toml `[project.optional-dependencies] nss` documentation. They install in both Python 3.12 and 3.13 matrix jobs.

## Test plan

- [ ] Smoke Tests (3.12) green — `searches/nest.py` no longer hits `ImportError: af.NSS requires the optional 'nss' package`
- [ ] Smoke Tests (3.13) green — same
- [ ] URL Check stays green (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)