### PR TITLE
PyAutoScientist 3b-2: Smoke Tests → thin caller

### DIFF
--- a/.github/scripts/smoke_install.sh
+++ b/.github/scripts/smoke_install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Workspace-owned install epilogue for the reusable Smoke Tests workflow
+# (PyAutoHeart/.github/workflows/smoke-tests.yml). Runs with cwd at the
+# checkout root (the dependency chain is cloned beside `workspace/`) and
+# receives PYTHON_VERSION. Everything that differs per workspace lives
+# here; the ceremony lives in the reusable workflow.
+set -e
+
+if [ "$PYTHON_VERSION" = "3.12" ]; then
+  pip install ./PyAutoConf "./PyAutoFit[optional]"
+else
+  pip install ./PyAutoConf ./PyAutoFit
+fi
+pip install nautilus-sampler
+# NSS sampler — searches/nest.py exercises `af.NSS`, which needs the
+# `[nss]` extra plus two manually-installed git pins. The SHAs match
+# PyAutoFit/pyproject.toml `[project.optional-dependencies] nss`.
+pip install "./PyAutoFit[nss]"
+pip install "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5"
+pip install "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
+pip install jupyter nbconvert ipynb-py-convert

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,96 +1,15 @@
 name: Smoke Tests
 
+# Thin caller for PyAutoHeart's reusable smoke-test workflow. The ceremony
+# (chain checkout, branch matching, runner, Slack) lives centrally; this
+# workspace declares its dependency chain and owns its install epilogue
+# (.github/scripts/smoke_install.sh) and runner (.github/scripts/run_smoke.py).
+
 on: [push, pull_request]
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.12', '3.13']
-    steps:
-    - name: Checkout PyAutoConf
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoConf
-        path: PyAutoConf
-    - name: Checkout PyAutoFit
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoFit
-        path: PyAutoFit
-    - name: Checkout PyAutoBuild
-      uses: actions/checkout@v4
-      with:
-        repository: PyAutoLabs/PyAutoBuild
-        path: PyAutoBuild
-    - name: Checkout workspace
-      uses: actions/checkout@v4
-      with:
-        path: workspace
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Extract branch name
-      id: extract_branch
-      shell: bash
-      run: |
-        cd workspace
-        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
-    - name: Match library branches
-      shell: bash
-      run: |
-        BRANCH="${{ steps.extract_branch.outputs.branch }}"
-        for PKG in PyAutoConf PyAutoFit; do
-          pushd "$PKG"
-          if [[ -n "$(git ls-remote --heads origin "$BRANCH")" ]]; then
-            echo "Branch $BRANCH exists in $PKG — checking out"
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-          else
-            echo "Branch $BRANCH not in $PKG — staying on main"
-          fi
-          popd
-        done
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip setuptools wheel
-        pip install pyyaml
-        if [ "${{ matrix.python-version }}" = "3.12" ]; then
-          pip install ./PyAutoConf "./PyAutoFit[optional]"
-        else
-          pip install ./PyAutoConf ./PyAutoFit
-        fi
-        pip install nautilus-sampler
-        # NSS sampler — searches/nest.py exercises `af.NSS`, which needs the
-        # `[nss]` extra plus two manually-installed git pins. The SHAs match
-        # PyAutoFit/pyproject.toml `[project.optional-dependencies] nss`.
-        pip install "./PyAutoFit[nss]"
-        pip install "blackjax @ git+https://github.com/handley-lab/blackjax.git@ef45acd2f2fa0cca15adbdcd3ff7cb3a98987cb5"
-        pip install "nss @ git+https://github.com/yallup/nss.git@69159b0f4a3a53123b9eec7df91e4ed3885e4dc4"
-        pip install jupyter nbconvert ipynb-py-convert
-    - name: Prepare cache dirs
-      run: |
-        mkdir -p /tmp/numba_cache /tmp/matplotlib
-    - name: Run smoke tests
-      env:
-        JAX_ENABLE_X64: "True"
-        NUMBA_CACHE_DIR: /tmp/numba_cache
-        MPLCONFIGDIR: /tmp/matplotlib
-        PYTHONPATH: ${{ github.workspace }}/PyAutoBuild/autobuild
-      run: |
-        cd workspace
-        python .github/scripts/run_smoke.py
-    - name: Slack notify on failure
-      if: ${{ failure() }}
-      uses: slackapi/slack-github-action@v1.21.0
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      with:
-        channel-id: C03S98FEDK2
-        payload: |
-          {
-            "text": "${{ github.repository }}/${{ github.ref_name }} smoke tests (Python ${{ matrix.python-version }}) ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }
+    uses: PyAutoLabs/PyAutoHeart/.github/workflows/smoke-tests.yml@main
+    with:
+      chain: "PyAutoConf PyAutoFit"
+    secrets: inherit


### PR DESCRIPTION
## Summary
Sweep conversion for [PyAutoHeart#51](https://github.com/PyAutoLabs/PyAutoHeart/issues/51): the fat `smoke_tests.yml` becomes a thin caller of Heart's reusable Smoke Tests workflow (merged, Heart#52), plus `.github/scripts/smoke_install.sh` carrying this repo's exact install block verbatim. Same workflow name, same matrix, same pip set (disclosed delta: PyAutoBuild always on PYTHONPATH; unused by this tier's runner where not needed).

Parity proven end-to-end on autolens_workspace#259 (both matrix jobs green through the reusable); this PR's own "Smoke Tests" check re-proves it for this repo's chain + epilogue.

## API Changes
None — CI only.

## Test Plan
- [ ] "Smoke Tests" check green on this PR via the reusable workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
