### PR TITLE
docs(features): wire built-in diagnostics into the EP walkthrough

### DIFF
--- a/scripts/features/expectation_propagation.py
+++ b/scripts/features/expectation_propagation.py
@@ -313,6 +313,32 @@ print(f"  means:  {mean_field.mean}")
 print(f"  scales: {mean_field.scale}")
 
 """
+__Diagnostics__
+
+PyAutoFit ships built-in tools for inspecting an EP fit. `mean_field_summary` prints the approximate posterior as a
+table — one row per variable with its mean and standard deviation — which is usually the first thing you want at the
+end of a fit:
+"""
+from autofit.graphical import mean_field_summary
+
+print(mean_field_summary(mean_field))
+
+"""
+The fit also emitted diagnostic artifacts into the output folder as it ran (they are overwritten live, so a running
+fit can be watched):
+
+ - `ep_history.csv`: one row per factor update — status, global log-evidence and the KL step size, the quantities
+   the convergence check in section 3.4 consumes.
+
+ - `mean_field_history.csv` / `mean_field_evolution.png`: every variable's mean ± std after each update — the message
+   field converging.
+
+ - `graph_factors.png`: per-factor evidence and KL curves, so one misbehaving factor is visible instead of being
+   averaged away in the global history.
+
+For long fits, `check_sigma_collapse` (also in `autofit.graphical`) inspects the history for posterior widths
+collapsing towards zero — a known failure mode of undamped EP.
+
 __Output Folder__
 
 The fit above wrote to `output/features/expectation_propagation`. Notable contents:


### PR DESCRIPTION
## Summary
Tracker #83 (follow-up from PyAutoFit#1335/#1349). New `__Diagnostics__` section at the end of `scripts/features/expectation_propagation.py`: a `mean_field_summary()` posterior table plus a tour of the live artifacts the diagnostics tooling emits during the fit (`ep_history.csv`, `mean_field_history.csv` / `mean_field_evolution.png`, `graph_factors.png`) and the `check_sigma_collapse` guard — so the walkthrough demonstrates the built-in tooling instead of stopping at the raw mean field.

## API Changes
None — workspace script only.

## Test Plan
- [x] Script compiles; the exact new imports/calls (`mean_field_summary`, `check_sigma_collapse`) exercised against the installed library and produce the expected table
- [x] Companion library PR: PyAutoFit#1354* (EP statistics completion) — no dependency; this section uses only #1349 API already on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)