### PR TITLE
docs: skip BlackJAXNUTS example when blackjax absent (Python matrix)

### DIFF
--- a/scripts/searches/mcmc.py
+++ b/scripts/searches/mcmc.py
@@ -264,7 +264,22 @@ Relevant links:
 
 If you use `BlackJAXNUTS` as part of a published work, please cite the BlackJAX package following
 the instructions on its GitHub page.
+
+`BlackJAXNUTS` needs the `blackjax` package, which ships with the `[optional]`
+extras (`pip install autofit[optional]`). When it is not installed (e.g. the
+NumPy-only CI matrix), skip the remaining NUTS section — the `Emcee` and `Zeus`
+examples above have already run.
 """
+import importlib.util
+import sys
+
+if importlib.util.find_spec("blackjax") is None:
+    print(
+        "Skipping BlackJAXNUTS example: the `blackjax` package is not installed "
+        "(install with `pip install autofit[optional]`)."
+    )
+    sys.exit(0)
+
 from autofit.jax.pytrees import enable_pytrees, register_model
 
 enable_pytrees()


### PR DESCRIPTION
## Summary

The PyAutoBuild **Python Version Matrix** installs the NumPy-only stack, so `scripts/searches/mcmc.py` failed with `ModuleNotFoundError: No module named 'blackjax'` — the `BlackJAXNUTS` section needs the optional **blackjax** package (ships via `autofit[optional]`).

Adds an `importlib.util.find_spec("blackjax")` guard before the NUTS section that skips it gracefully (prints a message and `sys.exit(0)`) when blackjax is absent. The `Emcee` and `Zeus` sections above run normally; under the full release stack the whole example runs unchanged.

## Verification
Ran against a clean 2026.7.9.1 venv (with emcee/zeus, without blackjax): Emcee and Zeus run, then the NUTS section prints the skip message and exits 0.

## Scripts Changed
- `scripts/searches/mcmc.py` — backend-absent guard on the NUTS section only. Notebook regenerates from the script on the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
