### PR TITLE
refactor: import config surface from autofit instead of autoconf

### DIFF
--- a/markdown/overview/overview_1_the_basics.md
+++ b/markdown/overview/overview_1_the_basics.md
@@ -48,7 +48,7 @@ To begin, lets import ``autofit`` (and ``numpy``) using the convention below:
 
 ```python
 
-from autoconf import setup_notebook; setup_notebook()
+from autofit import setup_notebook; setup_notebook()
 
 import autofit as af
 import autofit.plot as aplt

--- a/markdown/overview/overview_2_scientific_workflow.md
+++ b/markdown/overview/overview_2_scientific_workflow.md
@@ -48,7 +48,7 @@ This overview is split into the following sections:
 
 ```python
 
-from autoconf import setup_notebook; setup_notebook()
+from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from typing import Optional

--- a/notebooks/cookbooks/analysis.ipynb
+++ b/notebooks/cookbooks/analysis.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import numpy as np\n",

--- a/notebooks/cookbooks/configs.ipynb
+++ b/notebooks/cookbooks/configs.ipynb
@@ -68,7 +68,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/cookbooks/latent_variables.ipynb
+++ b/notebooks/cookbooks/latent_variables.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "\n",

--- a/notebooks/cookbooks/model.ipynb
+++ b/notebooks/cookbooks/model.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/cookbooks/model_internal.ipynb
+++ b/notebooks/cookbooks/model_internal.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import numpy as np"

--- a/notebooks/cookbooks/multi_level_model.ipynb
+++ b/notebooks/cookbooks/multi_level_model.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/cookbooks/multiple_datasets.ipynb
+++ b/notebooks/cookbooks/multiple_datasets.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/cookbooks/result.ipynb
+++ b/notebooks/cookbooks/result.ipynb
@@ -108,7 +108,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "from os import path\n",
@@ -789,7 +789,7 @@
     "            The paths object which manages all paths, e.g. where the non-linear search outputs are stored,\n",
     "            visualization, and the pickled objects used by the aggregator output by this function.\n",
     "        \"\"\"\n",
-    "        from autoconf.dictable import to_dict\n",
+    "        from autofit import to_dict\n",
     "\n",
     "        paths.save_json(name=\"data\", object_dict=to_dict(self.data))\n",
     "        paths.save_json(name=\"noise_map\", object_dict=to_dict(self.noise_map))\n",

--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -82,7 +82,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autofit.plot as aplt\n",

--- a/notebooks/cookbooks/search.ipynb
+++ b/notebooks/cookbooks/search.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/features/expectation_propagation.ipynb
+++ b/notebooks/features/expectation_propagation.ipynb
@@ -94,7 +94,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "\n",

--- a/notebooks/features/graphical_models.ipynb
+++ b/notebooks/features/graphical_models.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
@@ -363,7 +363,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "from autoconf.dictable import output_to_json, from_json\n",
+    "from autofit import output_to_json, from_json\n",
     "\n",
     "json_file = path.join(dataset_prefix_path, \"interpolator.json\")\n",
     "\n",

--- a/notebooks/features/model_comparison.ipynb
+++ b/notebooks/features/model_comparison.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/features/search_chaining.ipynb
+++ b/notebooks/features/search_chaining.ipynb
@@ -118,7 +118,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -715,7 +715,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/features/search_grid_search.ipynb
+++ b/notebooks/features/search_grid_search.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/features/shared_analysis_state.ipynb
+++ b/notebooks/features/shared_analysis_state.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/overview/overview_1_the_basics.ipynb
+++ b/notebooks/overview/overview_1_the_basics.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autofit.plot as aplt\n",

--- a/notebooks/overview/overview_2_scientific_workflow.ipynb
+++ b/notebooks/overview/overview_2_scientific_workflow.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from typing import Optional\n",

--- a/notebooks/plot/dynesty_plotter.ipynb
+++ b/notebooks/plot/dynesty_plotter.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/plot/emcee_plotter.ipynb
+++ b/notebooks/plot/emcee_plotter.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/plot/get_dist.ipynb
+++ b/notebooks/plot/get_dist.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "\n",
     "import numpy as np\n",

--- a/notebooks/plot/nautilus_plotter.ipynb
+++ b/notebooks/plot/nautilus_plotter.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/plot/zeus_plotter.ipynb
+++ b/notebooks/plot/zeus_plotter.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/searches/mcmc.ipynb
+++ b/notebooks/searches/mcmc.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/mle.ipynb
+++ b/notebooks/searches/mle.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/nest.ipynb
+++ b/notebooks/searches/nest.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/start_point.ipynb
+++ b/notebooks/searches/start_point.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/simulators/simulators.ipynb
+++ b/notebooks/simulators/simulators.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import util\n",
     "from os import path\n",

--- a/notebooks/simulators/simulators_sample.ipynb
+++ b/notebooks/simulators/simulators_sample.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "from autoconf import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/simulators/util.ipynb
+++ b/notebooks/simulators/util.ipynb
@@ -41,7 +41,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "from autoconf.dictable import to_dict\n",
+    "from autofit import to_dict\n",
     "\n",
     "import autofit as af\n",
     "\n",

--- a/scripts/cookbooks/analysis.py
+++ b/scripts/cookbooks/analysis.py
@@ -18,7 +18,7 @@ __Contents__
    files) to aid in the interpretation of results.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import json
 import numpy as np

--- a/scripts/cookbooks/configs.py
+++ b/scripts/cookbooks/configs.py
@@ -21,7 +21,7 @@ __Contents__
  - Labels: Config files which specify the labels of model component parameters for visualization.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from os import path

--- a/scripts/cookbooks/latent_variables.py
+++ b/scripts/cookbooks/latent_variables.py
@@ -31,7 +31,7 @@ __Contents__
  - When To Add A Latent vs A Sampled Parameter: A short rule-of-thumb.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import autofit as af
 

--- a/scripts/cookbooks/model.py
+++ b/scripts/cookbooks/model.py
@@ -50,7 +50,7 @@ the following sections:
  - Wrap Up: A summary of model composition in PyAutoFit.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import json
 import os

--- a/scripts/cookbooks/model_internal.py
+++ b/scripts/cookbooks/model_internal.py
@@ -25,7 +25,7 @@ __Contents__
  - Serialization Round Trip: ``dict()`` and ``from_dict()`` for JSON persistence.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import autofit as af
 import numpy as np

--- a/scripts/cookbooks/multi_level_model.py
+++ b/scripts/cookbooks/multi_level_model.py
@@ -23,7 +23,7 @@ __Contents__
  - Json Output (Model): Output a multi-level model in human readable text via a .json file and loading it back again.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import json
 import os

--- a/scripts/cookbooks/multiple_datasets.py
+++ b/scripts/cookbooks/multiple_datasets.py
@@ -43,7 +43,7 @@ __Contents__
  - Wrap Up: A summary of multi-dataset fitting in PyAutoFit.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/cookbooks/result.py
+++ b/scripts/cookbooks/result.py
@@ -61,7 +61,7 @@ The final section describes how to use results built in an sqlite database file:
  - Writing Directly To Database: Writing results directly to the database.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import json
 from os import path
@@ -535,7 +535,7 @@ class Analysis(af.Analysis):
             The paths object which manages all paths, e.g. where the non-linear search outputs are stored,
             visualization, and the pickled objects used by the aggregator output by this function.
         """
-        from autoconf.dictable import to_dict
+        from autofit import to_dict
 
         paths.save_json(name="data", object_dict=to_dict(self.data))
         paths.save_json(name="noise_map", object_dict=to_dict(self.noise_map))

--- a/scripts/cookbooks/samples.py
+++ b/scripts/cookbooks/samples.py
@@ -35,7 +35,7 @@ The following sections outline how to use advanced features of the results, whic
  - Samples Filtering (Advanced): Filter the `Samples` object to only contain samples fulfilling certain criteria.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import autofit as af
 import autofit.plot as aplt

--- a/scripts/cookbooks/search.py
+++ b/scripts/cookbooks/search.py
@@ -26,7 +26,7 @@ It then provides example code for using every search:
  - LBFGS: The L-BFGS scipy optimization.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from os import path

--- a/scripts/features/expectation_propagation.py
+++ b/scripts/features/expectation_propagation.py
@@ -47,7 +47,7 @@ The **PyAutoFit** source code has the following example objects (accessed via `a
 These are functionally identical to the `Analysis` and `Gaussian` objects used elsewhere in the workspace.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 from os import path
 

--- a/scripts/features/graphical_models.py
+++ b/scripts/features/graphical_models.py
@@ -48,7 +48,7 @@ The **PyAutoFit** source code has the following example objects (accessed via `a
 These are functionally identical to the `Analysis` and `Gaussian` objects you have seen elsewhere in the workspace.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 from os import path
 import matplotlib.pyplot as plt

--- a/scripts/features/interpolate.py
+++ b/scripts/features/interpolate.py
@@ -40,7 +40,7 @@ This script is split into the following sections:
 - **Database**: Load results from hard disk using the Aggregator for interpolation.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -231,7 +231,7 @@ The interpolator and model can be serialized to a .json file using **PyAutoConf*
 
 This means an interpolator can easily be loaded into other scripts.
 """
-from autoconf.dictable import output_to_json, from_json
+from autofit import output_to_json, from_json
 
 json_file = path.join(dataset_prefix_path, "interpolator.json")
 

--- a/scripts/features/model_comparison.py
+++ b/scripts/features/model_comparison.py
@@ -52,7 +52,7 @@ This script is split into the following sections:
 - **Wrap Up**: Summarize the model comparison results using log likelihood and Bayesian evidence.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/features/search_chaining.py
+++ b/scripts/features/search_chaining.py
@@ -71,7 +71,7 @@ The **PyAutoFit** source code has the following example objects (accessed via `a
 These are functionally identical to the `Analysis` and `Gaussian` objects you have seen elsewhere in the workspace.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -439,7 +439,7 @@ and change its parameterization between each fit.
 
 This cookbook is a concise reference to the model linking API.
 """
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import json
 import os

--- a/scripts/features/search_grid_search.py
+++ b/scripts/features/search_grid_search.py
@@ -53,7 +53,7 @@ This script is split into the following sections:
 - **Search Grid Search**: Set up and perform a grid search over a parameter subset.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/features/sensitivity_mapping.py
+++ b/scripts/features/sensitivity_mapping.py
@@ -48,7 +48,7 @@ This script is split into the following sections:
 - **Results**: Interpret the sensitivity mapping results.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/features/shared_analysis_state.py
+++ b/scripts/features/shared_analysis_state.py
@@ -56,7 +56,7 @@ The **PyAutoFit** source code has the following example objects (accessed via `a
  - `Gaussian`: a model component representing a 1D Gaussian profile.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 from os import path
 import matplotlib.pyplot as plt

--- a/scripts/overview/overview_1_the_basics.py
+++ b/scripts/overview/overview_1_the_basics.py
@@ -43,7 +43,7 @@ This overview is split into the following sections:
 To begin, lets import ``autofit`` (and ``numpy``) using the convention below:
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import autofit as af
 import autofit.plot as aplt

--- a/scripts/overview/overview_2_scientific_workflow.py
+++ b/scripts/overview/overview_2_scientific_workflow.py
@@ -43,7 +43,7 @@ This overview is split into the following sections:
 - **Wrap Up**: Summary of scientific workflow features in PyAutoFit.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from typing import Optional

--- a/scripts/plot/dynesty_plotter.py
+++ b/scripts/plot/dynesty_plotter.py
@@ -15,7 +15,7 @@ This script is split into the following sections:
 - **Plots**: Producing Dynesty-specific diagnostic plots.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 from os import path

--- a/scripts/plot/emcee_plotter.py
+++ b/scripts/plot/emcee_plotter.py
@@ -14,7 +14,7 @@ This script is split into the following sections:
 - **Search Specific Visualization**: Accessing the native Emcee sampler for custom visualizations.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 from os import path

--- a/scripts/plot/get_dist.py
+++ b/scripts/plot/get_dist.py
@@ -36,7 +36,7 @@ This script is split into the following sections:
 - **Plotting Multiple Samples**: Demonstrate plotting results from multiple searches.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 
 import numpy as np

--- a/scripts/plot/nautilus_plotter.py
+++ b/scripts/plot/nautilus_plotter.py
@@ -15,7 +15,7 @@ This script is split into the following sections:
 - **Plots**: Producing Nautilus-specific diagnostic plots.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from os import path

--- a/scripts/plot/zeus_plotter.py
+++ b/scripts/plot/zeus_plotter.py
@@ -14,7 +14,7 @@ This script is split into the following sections:
 - **Search Specific Visualization**: Accessing the native Zeus sampler for custom visualizations.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 from os import path

--- a/scripts/searches/mcmc.py
+++ b/scripts/searches/mcmc.py
@@ -26,7 +26,7 @@ This script is split into the following sections:
 - **Search Internal**: Accessing the internal sampler for advanced use (shown once for Emcee).
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/searches/mle.py
+++ b/scripts/searches/mle.py
@@ -28,7 +28,7 @@ This script is split into the following sections:
 - **Search: MultiStartAdam**: Running the JAX multi-start gradient MAP optimizer.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/searches/nest.py
+++ b/scripts/searches/nest.py
@@ -27,7 +27,7 @@ This script is split into the following sections:
 - **Search Internal**: Accessing the internal sampler for advanced use (shown once for DynestyStatic).
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/scripts/searches/start_point.py
+++ b/scripts/searches/start_point.py
@@ -57,7 +57,7 @@ __Start Here Notebook__
 If any code in this script is unclear, refer to the `modeling/start_here.ipynb` notebook.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import matplotlib.pyplot as plt
 from os import path

--- a/scripts/simulators/simulators.py
+++ b/scripts/simulators/simulators.py
@@ -26,7 +26,7 @@ This script is split into the following sections:
 - **Gaussian x1 time**: Simulate time-varying Gaussian datasets.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import util
 from os import path

--- a/scripts/simulators/simulators_sample.py
+++ b/scripts/simulators/simulators_sample.py
@@ -13,7 +13,7 @@ This script is split into the following sections:
 - **Gaussian x2 offset centre**: Simulate datasets with two Gaussians with offset centres for graphical model demonstrations.
 """
 
-# from autoconf import setup_notebook; setup_notebook()
+# from autofit import setup_notebook; setup_notebook()
 
 import numpy as np
 from os import path

--- a/scripts/simulators/util.py
+++ b/scripts/simulators/util.py
@@ -1,4 +1,4 @@
-from autoconf.dictable import to_dict
+from autofit import to_dict
 
 import autofit as af
 


### PR DESCRIPTION
## What

Rewrite `from autoconf[.sub] import X` → `from autofit import X` across scripts, notebooks and markdown, so workspace code imports the config/serialization surface (`conf`, `jax_wrapper`, `with_test_mode_segment`, `dictable`/`fitsable` helpers, …) through the science library rather than depending on `autoconf` directly.

## Notes

- The Colab bootstrap `from autoconf import setup_colab` is intentionally left on `autoconf` — it runs before the library is pip-installed on Colab.
- Notebooks were updated by the same deterministic line-level transform as the scripts (catalogue files embed no import lines and are unaffected).
- Pairs with the `autofit` re-export PR on the same-named branch; the smoke/navigator jobs check out that branch.

## Validation

CI running on this branch (push-triggered) — please confirm Smoke Tests / Navigator Check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_