### PR TITLE
fix: run notebook smoke from the workspace root so dataset paths resolve

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -101,6 +101,13 @@ def execute_notebook(nb_path: Path, env: dict) -> tuple[int, str]:
     # Write the executed copy to a throwaway path so the on-disk notebook
     # under notebooks/ is never modified — checked-in notebooks stay clean.
     tmp_dir = Path(tempfile.mkdtemp(prefix="smoke_nb_"))
+    # `jupyter nbconvert --execute` runs the kernel in the *notebook's own
+    # directory*, but the workspace convention (and the script smoke, which runs
+    # with cwd=WORKSPACE) is that relative `dataset/` paths resolve from the repo
+    # root. Stage a temporary copy of the notebook at the workspace root so the
+    # kernel's working directory is the root and root-relative paths resolve.
+    staged = WORKSPACE / f".smoke_run_{os.getpid()}_{nb_path.name}"
+    shutil.copyfile(nb_path, staged)
     try:
         result = subprocess.run(
             [
@@ -113,7 +120,7 @@ def execute_notebook(nb_path: Path, env: dict) -> tuple[int, str]:
                 str(tmp_dir),
                 "--output",
                 nb_path.name,
-                str(nb_path),
+                str(staged),
             ],
             cwd=str(WORKSPACE),
             env=env,
@@ -121,6 +128,7 @@ def execute_notebook(nb_path: Path, env: dict) -> tuple[int, str]:
             text=True,
         )
     finally:
+        staged.unlink(missing_ok=True)
         shutil.rmtree(tmp_dir, ignore_errors=True)
     return result.returncode, result.stdout + result.stderr
 


### PR DESCRIPTION
## Problem

The notebook smoke fails because `jupyter nbconvert --execute` runs the kernel in the **notebook's own directory** (e.g. `notebooks/overview/`), not the workspace root. Notebooks resolve repo-root-relative paths — reading `dataset/example_1d/...` and, via the auto-simulate fallback, invoking `scripts/simulators/simulators.py` — matching the workspace "run from the repo root" convention and the script smoke's `cwd=WORKSPACE`. From the notebook's subdirectory those paths don't resolve, so the notebook fails.

This is a recent regression (nbconvert now runs the kernel in the notebook's directory) affecting every workspace whose notebooks read committed datasets; it is unrelated to any library change.

## Fix

`.github/scripts/run_smoke.py`: stage a temporary copy of the notebook at the workspace root before executing, so the kernel's working directory is the root and root-relative paths resolve. Verified locally that in-place execution fails while root-staged execution reads the dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_