### PR TITLE
chore: un-park features/interpolate (stale NEEDS_FIX, bug fixed)

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -22,4 +22,3 @@
 - zeus_plotter # Test Model Iniitalization no good.
 - dynesty_plotter # Test Model Iniitalization no good.
 - start_point # bug https://github.com/rhayes777/PyAutoFit/issues/1017
-- features/interpolate # NEEDS_FIX 2026-04-10 - IndexError in InstanceInterpolator.__getitem__ when querying time == 1.5; value_map lookup falls through to empty instances list


### PR DESCRIPTION
Removes the stale `# NEEDS_FIX 2026-04-10` marker on `features/interpolate` — the InstanceInterpolator IndexError at t=1.5 no longer reproduces (exit 0).

Closes part of PyAutoLabs/autolens_workspace_test#191.

Parked-script triage: reproduced on clean main under PYAUTO_TEST_MODE=2 (the harness mode). Verified fixed → un-parked (removed the NEEDS_FIX marker so the script runs in validation again).

## Scripts Changed

None (config-only edit to config/build/no_run.yaml). The following previously-skipped script returns to validation:
- `scripts/features/interpolate.py`