### PR TITLE
fix(interpolate): select instances by time, not list position

### DIFF
--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -330,18 +330,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `centre` of the `Gaussian` at time 1.5 is between the value inferred for the first and second fits taken\n",
-    "at times 1.0 and 2.0.\n",
+    "The `centre` of the `Gaussian` at time 1.5 is between the value inferred for the fits taken at times 1.0 and 2.0.\n",
     "\n",
-    "This is a `centre` close to a value of 55.0."
+    "This is a `centre` close to a value of 55.0.\n",
+    "\n",
+    "We select the instances to print by matching on their `time` attribute rather than by their position in\n",
+    "`ml_instances_list`. Position and time are not interchangeable, and relying on position is what makes this kind of\n",
+    "comparison silently wrong (see the aggregator section below, where the loaded order is not the fit order)."
    ]
   },
   {
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "print(f\"Gaussian centre of fit 1 (t = 1): {ml_instances_list[0].gaussian.centre}\")\n",
-    "print(f\"Gaussian centre of fit 2 (t = 2): {ml_instances_list[1].gaussian.centre}\")\n",
+    "\n",
+    "\n",
+    "def instance_at_time(instances, time):\n",
+    "    return next(inst for inst in instances if inst.time == time)\n",
+    "\n",
+    "\n",
+    "print(\n",
+    "    f\"Gaussian centre of fit at t = 1: {instance_at_time(ml_instances_list, 1).gaussian.centre}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Gaussian centre of fit at t = 2: {instance_at_time(ml_instances_list, 2).gaussian.centre}\"\n",
+    ")\n",
     "\n",
     "print(f\"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}\")\n"
    ],
@@ -401,14 +414,37 @@
     "    directory=path.join(\"output\", \"interpolate\"), completed_only=False\n",
     ")\n",
     "\n",
-    "ml_instances_list = [samps.max_log_likelihood() for samps in agg.values(\"samples\")]\n",
+    "ml_instances_list = [samps.max_log_likelihood() for samps in agg.values(\"samples\")]"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The aggregator does not guarantee that results are loaded in the order the fits were performed \u2014 here, for example,\n",
+    "they come back in the order t=0, t=2, t=1.\n",
     "\n",
+    "This does not affect the interpolation at all, because the `LinearInterpolator` keys each instance by its `time`\n",
+    "attribute and sorts them internally. It does mean you should never assume `ml_instances_list[i]` is the i'th fit,\n",
+    "which is why we again select by `time` below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
     "interpolator = af.LinearInterpolator(instances=ml_instances_list)\n",
     "\n",
     "instance = interpolator[interpolator.time == 1.5]\n",
     "\n",
-    "print(f\"Gaussian centre of fit 1 (t = 1): {ml_instances_list[0].gaussian.centre}\")\n",
-    "print(f\"Gaussian centre of fit 2 (t = 2): {ml_instances_list[1].gaussian.centre}\")\n",
+    "print(\n",
+    "    f\"Gaussian centre of fit at t = 1: {instance_at_time(ml_instances_list, 1).gaussian.centre}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"Gaussian centre of fit at t = 2: {instance_at_time(ml_instances_list, 2).gaussian.centre}\"\n",
+    ")\n",
     "\n",
     "print(f\"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}\")"
    ],

--- a/scripts/features/interpolate.py
+++ b/scripts/features/interpolate.py
@@ -213,13 +213,26 @@ by interpolating between the values computed above.
 instance = interpolator[interpolator.time == 1.5]
 
 """
-The `centre` of the `Gaussian` at time 1.5 is between the value inferred for the first and second fits taken
-at times 1.0 and 2.0.
+The `centre` of the `Gaussian` at time 1.5 is between the value inferred for the fits taken at times 1.0 and 2.0.
 
 This is a `centre` close to a value of 55.0.
+
+We select the instances to print by matching on their `time` attribute rather than by their position in
+`ml_instances_list`. Position and time are not interchangeable, and relying on position is what makes this kind of
+comparison silently wrong (see the aggregator section below, where the loaded order is not the fit order).
 """
-print(f"Gaussian centre of fit 1 (t = 1): {ml_instances_list[0].gaussian.centre}")
-print(f"Gaussian centre of fit 2 (t = 2): {ml_instances_list[1].gaussian.centre}")
+
+
+def instance_at_time(instances, time):
+    return next(inst for inst in instances if inst.time == time)
+
+
+print(
+    f"Gaussian centre of fit at t = 1: {instance_at_time(ml_instances_list, 1).gaussian.centre}"
+)
+print(
+    f"Gaussian centre of fit at t = 2: {instance_at_time(ml_instances_list, 2).gaussian.centre}"
+)
 
 print(f"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}")
 
@@ -260,12 +273,24 @@ agg = Aggregator.from_directory(
 
 ml_instances_list = [samps.max_log_likelihood() for samps in agg.values("samples")]
 
+"""
+The aggregator does not guarantee that results are loaded in the order the fits were performed — here, for example,
+they come back in the order t=0, t=2, t=1.
+
+This does not affect the interpolation at all, because the `LinearInterpolator` keys each instance by its `time`
+attribute and sorts them internally. It does mean you should never assume `ml_instances_list[i]` is the i'th fit,
+which is why we again select by `time` below.
+"""
 interpolator = af.LinearInterpolator(instances=ml_instances_list)
 
 instance = interpolator[interpolator.time == 1.5]
 
-print(f"Gaussian centre of fit 1 (t = 1): {ml_instances_list[0].gaussian.centre}")
-print(f"Gaussian centre of fit 2 (t = 2): {ml_instances_list[1].gaussian.centre}")
+print(
+    f"Gaussian centre of fit at t = 1: {instance_at_time(ml_instances_list, 1).gaussian.centre}"
+)
+print(
+    f"Gaussian centre of fit at t = 2: {instance_at_time(ml_instances_list, 2).gaussian.centre}"
+)
 
 print(f"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}")
 


### PR DESCRIPTION
Found while clearing this script's stale NEEDS_FIX marker (PyAutoLabs/PyAutoFit#1411). Script always exited 0 and **the interpolation was always correct** — these are labelling bugs that made the tutorial's headline claim unverifiable.

### 1. Off-by-one in the labels (both blocks)

`ml_instances_list[0]` is the **t=0** fit and `[1]` is **t=1** — the list is built by `for time in range(3)`. Both blocks labelled them `fit 1 (t = 1)` and `fit 2 (t = 2)`. The prose then invited the reader to bracket the interpolated t=1.5 centre between two numbers that were actually the t=0 and t=1 fits, so the check demonstrated nothing.

### 2. The aggregator does not return fit order

Verified against a real `output/interpolate`:

| time | centre |
|---|---|
| 0 | 40.049 |
| 2 | 59.731 | ← index 1 |
| 1 | 49.963 |

That is why the aggregator block printed a different "fit 2" (59.73) than the in-memory block (49.96) for the same three fits — presented without comment, as if the round-trip changed the result.

### Fix

Both blocks now select via a small `instance_at_time()` helper, so position can never drift from time again, and the prose explains that aggregator ordering is not guaranteed to be fit order (a genuinely useful lesson here).

Interpolation was never affected — `_value_map` keys by `time` and sorts internally. After the fix both blocks print identical values and 54.834 visibly brackets between 49.96 and 59.73, making the script's "close to 55.0" claim demonstrable.

Verified: exit 0, real run. Notebook regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)