### PR TITLE
docs: update tested-against version to 2026.7.22.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following **projects** are available in the project folder:
 
 ## Workspace Version
 
-This version of the workspace are built and tested for using **PyAutoFit v2026.7.22.1**.
+This version of the workspace are built and tested for using **PyAutoFit v2026.7.23.1**.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following **projects** are available in the project folder:
 
 ## Workspace Version
 
-This version of the workspace are built and tested for using **PyAutoFit v2026.7.9.1**.
+This version of the workspace are built and tested for using **PyAutoFit v2026.7.22.1**.
 
 ## Support
 


### PR DESCRIPTION
`README.md` claimed the workspace is "built and tested for using **PyAutoFit v2026.7.9.1**". The release's version-bump script missed this phrasing, so it stayed stale while the rest of the workspace docs moved to `2026.7.22.1`.

Not changed: `config/general.yaml` → `minimum_library_version`, which its own comment says to "bump DELIBERATELY — only when a script starts needing new API — never per release".