### PR TITLE
docs(readme): drop the orphaned library version pin (#155 Phase 4 task 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ The following **projects** are available in the project folder:
 
 ## Workspace Version
 
-This version of the workspace are built and tested for using **PyAutoFit v2026.7.9.1**.
+This workspace is built and tested against the **latest PyAutoFit release** — install it with
+`pip install --upgrade autofit`.
+
+The oldest release the scripts here are compatible with is recorded as
+`version.minimum_library_version` in `config/general.yaml`, and is checked when the workspace
+runs. That floor is the authoritative compatibility signal; this README no longer names an
+exact version, which could go stale (or name a yanked release) between releases.
 
 ## Support
 


### PR DESCRIPTION
Drops the orphaned `<pkg> vX` line from this README (build-chain campaign PyAutoHands#155, Phase 4 task 4).

**Why it was orphaned:** the release runner stopped bumping the pin under PyAutoBuild#120/#121, and `pre_build`s local sed never staged its edit (deleted in #158). Nothing has owned it since — the pins were up to ~2 months stale, and after 2026.7.9.1 one of them named a *yanked* release.

**Decision (user, this session):** drop the pins rather than give the runner ownership again. Re-adding a runner-side sed+commit means a new commit-to-`main` step of the kind #120/#121 deliberately removed, to maintain a string no gate reads. The machine-checked signal is `version.minimum_library_version` in `config/general.yaml`, which Heart `version_skew` verifies against the newest release tag (all 7 floors OK on todays 2026.7.22.1).

Docs-only; no script, config, or notebook touched.