### PR TITLE
refactor: rename autobuild package and CLI to autohands

### DIFF
--- a/.claude/skills/generate_and_merge/SKILL.md
+++ b/.claude/skills/generate_and_merge/SKILL.md
@@ -19,7 +19,7 @@ Build notebooks for the autofit_workspace, then open and merge a PR into `main`,
 
    Run from the workspace root:
    ```bash
-   PYTHONPATH=../PyAutoHands/autobuild python3 ../PyAutoHands/autobuild/generate.py autofit
+   PYTHONPATH=../PyAutoHands/autohands python3 ../PyAutoHands/autohands/generate.py autofit
    ```
    This regenerates all notebooks in `notebooks/` from `scripts/`. It may take a few minutes.
    It also regenerates the LLM-facing catalogue (`llms-full.txt` and `workspace_index.json`)

--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -139,7 +139,7 @@ def regenerate_notebook(nb_rel: str) -> Path:
     The regenerated copy lives in /tmp; the on-disk `notebooks/` tree is
     never modified, so a smoke run leaves the worktree clean.
     """
-    from build_util import py_to_notebook  # PyAutoHands/autobuild on PYTHONPATH
+    from build_util import py_to_notebook  # PyAutoHands/autohands on PYTHONPATH
 
     script_path = SCRIPTS_DIR / Path(nb_rel).with_suffix(".py")
     if not script_path.exists():

--- a/.github/workflows/navigator_check.yml
+++ b/.github/workflows/navigator_check.yml
@@ -2,7 +2,7 @@ name: Navigator Check
 
 # Thin caller for PyAutoHands's reusable navigator-catalogue check. The check
 # logic (path/banner lint + catalogue staleness) and its entrypoints live in
-# PyAutoHands/autobuild; this workspace only declares which generator project to
+# PyAutoHands/autohands; this workspace only declares which generator project to
 # run. See PyAutoLabs/PyAutoHands/.github/workflows/navigator_check.yml.
 
 on: [push, pull_request]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ root):
 ```bash
 pip install ipynb-py-convert
 git clone https://github.com/PyAutoLabs/PyAutoHands.git ../PyAutoHands
-PYTHONPATH=../PyAutoHands/autobuild python3 ../PyAutoHands/autobuild/generate.py autofit
+PYTHONPATH=../PyAutoHands/autohands python3 ../PyAutoHands/autohands/generate.py autofit
 ```
 
 Commit the regenerated notebooks alongside the script changes. The `/generate_and_merge` skill

--- a/config/build/visualise_notebooks.yaml
+++ b/config/build/visualise_notebooks.yaml
@@ -4,7 +4,7 @@
 # Format: flat list of notebook stems (no extension, no path).
 # An empty list means no notebooks need re-visualisation in this workspace.
 #
-# This file overrides PyAutoHands/autobuild/config/visualise_notebooks.yaml
+# This file overrides PyAutoHands/autohands/config/visualise_notebooks.yaml
 # for this workspace. Add or remove entries here, not there.
 
 []


### PR DESCRIPTION
## Rename `autobuild` → `autohands`

Part of a coordinated **18-repo** rename tracked in [PyAutoHands#177](https://github.com/PyAutoLabs/PyAutoHands/issues/177). The Hands repo was renamed `PyAutoBuild` → `PyAutoHands`, but its payload package and CLI kept the old name; this closes that seam.

**In this repo:** `AGENTS.md` generate command (`PYTHONPATH=../PyAutoHands/autohands …`), `.github/scripts/run_smoke.py` `sys.path.insert`, `.claude/skills/*/SKILL.md`, and `config/build/*.yaml` + `navigator_check.yml` header comments.

> ### ⚠️ Merge order matters — this lands atomically, with no back-compat shim
>
> ```
> 1. PyAutoHands      (the package + CLI move)
> 2. PyAutoHeart      (workspace-validation.yml calls the moved paths)
> 3. PyAutoBrain      (resolver + policy + repo maps)
> 4. everything else  (workspaces, HowTos, assistants, Mind, admin_jammy)
> ```
>
> The directory move breaks PyAutoHeart's `workspace-validation.yml` and every workspace's `run_smoke.py` **the moment PyAutoHands merges**. All 18 should merge in one pass, ideally while CI is quiet. That window is the accepted cost of landing without a shim.

### Deliberately preserved

`PyAutoBuild#NNN` issue citations, the `rhayes777/PyAutoBuild` url_fixups patterns, the `pyautobuild: pyautohands` policy alias, `pyautobuild_boundary_audit.md`, ~150 PyAutoMind historical records, and the `PYAUTOBUILD_DIR` docstring describing a shim that no longer exists. `autobuild` is also **kept as a back-compat router keyword** in `policy.yaml` / `_intake.py` / `_bug.py` — those are typed keywords, not paths.

### Verification (whole-branch)

- PyAutoHands **148 passed**; PyAutoBrain **152 passed, 1 failed** — `test_skill_install` (`sizing` wrapper), confirmed **pre-existing on main**.
- `repos_sync.py --check` matches the `main` baseline exactly. Not vacuous: `FIREWALL_ALLOWLIST` is keyed by real path, so a missed rename would surface all 13 moved modules as violations.
- `bash -n` clean on every moved shell script; `autohands help` renders.
- Every `PyAutoHands/autohands/<module>` reference in the workspace resolves to a real file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
