### PR TITLE
chore: delete dead PYAUTO_SMALL_DATASETS/PYAUTO_FAST_PLOTS from build profiles

### DIFF
--- a/config/build/env_vars.yaml
+++ b/config/build/env_vars.yaml
@@ -13,9 +13,7 @@ defaults:
   PYAUTO_SKIP_FIT_OUTPUT: "1"               # Skip pre/post-fit I/O, VRAM profiling, result text
   PYAUTO_SKIP_VISUALIZATION: "1"            # Skip fit visualization and plotting
   PYAUTO_SKIP_CHECKS: "1"                   # Skip mesh validation, position checks, weight thresholds
-  PYAUTO_SMALL_DATASETS: "1"                # Cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "1"                   # Force use_jax=False, avoid JIT compilation overhead
-  PYAUTO_FAST_PLOTS: "1"                    # Skip tight_layout() + critical curve/caustic overlays
   JAX_ENABLE_X64: "True"                    # Enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"       # Writable cache dir for numba
   MPLCONFIGDIR: "/tmp/matplotlib"           # Writable config dir for matplotlib

--- a/config/build/env_vars_release.yaml
+++ b/config/build/env_vars_release.yaml
@@ -30,9 +30,7 @@ defaults:
   PYAUTO_SKIP_FIT_OUTPUT: "0"               # real fit output (release fidelity, not smoke)
   PYAUTO_SKIP_VISUALIZATION: "0"            # real visualization (release fidelity, not smoke)
   PYAUTO_SKIP_CHECKS: "0"                   # real checks (release fidelity, not smoke)
-  PYAUTO_SMALL_DATASETS: "1"                # cap grids/masks to 15x15, reduce MGE gaussians
   PYAUTO_DISABLE_JAX: "0"                   # JAX enabled (release fidelity, not smoke)
-  PYAUTO_FAST_PLOTS: "1"                    # skip tight_layout() + critical curve/caustic overlays
   PYAUTO_SKIP_WORKSPACE_VERSION_CHECK: "1"  # TestPyPI dev version won't match the workspace pin
   JAX_ENABLE_X64: "True"                    # enable 64-bit precision in JAX
   NUMBA_CACHE_DIR: "/tmp/numba_cache"       # writable cache dir for numba


### PR DESCRIPTION
## Summary

`PYAUTO_SMALL_DATASETS` and `PYAUTO_FAST_PLOTS` are **dead config** here — nothing that reads them is ever imported in an autofit-only workspace. This deletes them from the `defaults:` block of this repo's build profile(s).

- `PYAUTO_SMALL_DATASETS` is read only in PyAutoArray (`util/dataset_util.py`, `structures/grids/uniform_2d.py`, `mask/mask_2d.py`, `operators/over_sampling/over_sample_util.py`, `operators/convolver.py`), PyAutoGalaxy and PyAutoLens. **Zero** occurrences in PyAutoFit or PyAutoNerves — not even a docstring.
- `PYAUTO_FAST_PLOTS` is read in `autoarray/plot/utils.py` and `autogalaxy/util/plot_utils.py`. In PyAutoFit it appears only in prose (`autofit/non_linear/quick_update.py:71` and a test docstring), never in an `os.environ` lookup.
- PyAutoFit does not import autoarray, and no script in this repo imports autoarray / autogalaxy / autolens — so the reading code never loads.
- PyAutoFit's single `tight_layout()` is in `autofit/non_linear/live_viewer.py:102`, inside the interactive `plt.ion()` desktop viewer, which never runs headless in CI. Wiring `PYAUTO_FAST_PLOTS` up there would buy nothing, so deletion is the right call rather than implementation.

The stale comments gave the copy-paste origin away: an autofit config claiming to "reduce MGE gaussians" and skip "critical curve/caustic overlays", both lensing concepts.

This does **not** violate the release-profile doctrine ("every var this profile cares about gets an EXPLICIT value, not left absent") — autofit cares about neither, so absence is correct rather than a fall-through hazard. `autofit_workspace_test/config/build/env_vars_release.yaml` already omitted both and is untouched.

Follow-up to #321 (the env_vars key-order sweep), which made the profiles diffable and surfaced this.

## Scripts Changed

None — configuration only. No file under `scripts/` is touched.

- `config/build/env_vars*.yaml` — removed the two dead `defaults:` entries. No `overrides:` entry referenced either key, so the change is contained to `defaults:`.

## Test Plan

- [x] **Resolved-env delta is exactly the two keys.** Across 227 script×profile environments in the three affected repos, resolved from an empty base via `resolve_clean()` (`PyAutoHands/autohands/validate_env_profiles.py`): only `PYAUTO_SMALL_DATASETS` and `PYAUTO_FAST_PLOTS` disappear. Zero other key added, removed or changed; `overrides:` and `args_default` byte-identical in every profile.
- [x] `validate_env_profiles.py` verdict unchanged from `main`.
- [x] `git diff --stat` contains nothing but `config/build/env_vars*.yaml`.
- [x] Re-grepped: no `.py` in autofit_workspace / autofit_workspace_test / HowToFit references either var.

Refs PyAutoLabs/autofit_workspace#111.

Generated by the PyAutoLabs agent workflow.
