### PR TITLE
chore: drop legacy env_vars.yaml fallback from run_smoke (#161 step 6, stage 3)

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -37,9 +37,6 @@ WORKSPACE = Path(__file__).resolve().parents[2]
 SMOKE_FILE = WORKSPACE / "smoke_tests.txt"
 NOTEBOOK_FILE = WORKSPACE / "smoke_notebooks.txt"
 ENV_VARS_FILE = WORKSPACE / "config" / "build" / "profile_smoke.yaml"
-# Legacy fallback for the rename transition; dies at the stage-3 cleanup.
-if not ENV_VARS_FILE.exists():
-    ENV_VARS_FILE = WORKSPACE / "config" / "build" / "env_vars.yaml"
 SCRIPTS_DIR = WORKSPACE / "scripts"
 NOTEBOOKS_DIR = WORKSPACE / "notebooks"
 


### PR DESCRIPTION
## Summary
Step 6 stage 3 (PyAutoHands#181): the vendored `.github/scripts/run_smoke.py` drops its migration-window legacy fallback and reads `config/build/profile_smoke.yaml` directly. The PyAutoHands validator now errors on legacy-named files, so the old name cannot return.

## Scripts Changed
- `.github/scripts/run_smoke.py` — legacy `env_vars.yaml` fallback removed (plain canonical assignment; AST-parse verified; repo grep for the old name returns nothing)

## Test Plan
- [x] `env_vars` grep clean; runner parses
- [ ] This PR's smoke gate green (the runner exercising the canonical-only path)

## Heart gate
Continuation of today's #181 work under the same human-acknowledged pre-existing RED. Independent of the sibling stage-3 PRs.

Generated by the PyAutoLabs agent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
