### PR TITLE
refactor: hide autonerves in AutoFit Colab setup

### DIFF
--- a/notebooks/cookbooks/analysis.ipynb
+++ b/notebooks/cookbooks/analysis.ipynb
@@ -46,18 +46,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/configs.ipynb
+++ b/notebooks/cookbooks/configs.ipynb
@@ -49,18 +49,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/latent_variables.ipynb
+++ b/notebooks/cookbooks/latent_variables.ipynb
@@ -59,18 +59,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/model.ipynb
+++ b/notebooks/cookbooks/model.ipynb
@@ -78,18 +78,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/model_internal.ipynb
+++ b/notebooks/cookbooks/model_internal.ipynb
@@ -53,18 +53,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/multi_level_model.ipynb
+++ b/notebooks/cookbooks/multi_level_model.ipynb
@@ -51,18 +51,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/multiple_datasets.ipynb
+++ b/notebooks/cookbooks/multiple_datasets.ipynb
@@ -71,18 +71,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/result.ipynb
+++ b/notebooks/cookbooks/result.ipynb
@@ -89,18 +89,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -63,18 +63,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/cookbooks/search.ipynb
+++ b/notebooks/cookbooks/search.ipynb
@@ -54,18 +54,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/expectation_propagation.ipynb
+++ b/notebooks/features/expectation_propagation.ipynb
@@ -75,18 +75,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/graphical_models.ipynb
+++ b/notebooks/features/graphical_models.ipynb
@@ -76,18 +76,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -68,18 +68,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/model_comparison.ipynb
+++ b/notebooks/features/model_comparison.ipynb
@@ -80,18 +80,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/search_chaining.ipynb
+++ b/notebooks/features/search_chaining.ipynb
@@ -99,18 +99,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/search_grid_search.ipynb
+++ b/notebooks/features/search_grid_search.ipynb
@@ -81,18 +81,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -76,18 +76,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/features/shared_analysis_state.ipynb
+++ b/notebooks/features/shared_analysis_state.ipynb
@@ -84,18 +84,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/overview/overview_1_the_basics.ipynb
+++ b/notebooks/overview/overview_1_the_basics.ipynb
@@ -71,18 +71,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/overview/overview_2_scientific_workflow.ipynb
+++ b/notebooks/overview/overview_2_scientific_workflow.ipynb
@@ -71,18 +71,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/overview/overview_3_statistical_methods.ipynb
+++ b/notebooks/overview/overview_3_statistical_methods.ipynb
@@ -152,18 +152,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/plot/dynesty_plotter.ipynb
+++ b/notebooks/plot/dynesty_plotter.ipynb
@@ -43,18 +43,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/plot/emcee_plotter.ipynb
+++ b/notebooks/plot/emcee_plotter.ipynb
@@ -42,18 +42,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/plot/get_dist.ipynb
+++ b/notebooks/plot/get_dist.ipynb
@@ -64,18 +64,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/plot/nautilus_plotter.ipynb
+++ b/notebooks/plot/nautilus_plotter.ipynb
@@ -43,18 +43,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/plot/zeus_plotter.ipynb
+++ b/notebooks/plot/zeus_plotter.ipynb
@@ -42,18 +42,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/searches/mcmc.ipynb
+++ b/notebooks/searches/mcmc.ipynb
@@ -54,18 +54,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/searches/mle.ipynb
+++ b/notebooks/searches/mle.ipynb
@@ -56,18 +56,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/searches/nest.ipynb
+++ b/notebooks/searches/nest.ipynb
@@ -55,18 +55,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/searches/start_point.ipynb
+++ b/notebooks/searches/start_point.ipynb
@@ -85,18 +85,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/simulators/simulators.ipynb
+++ b/notebooks/simulators/simulators.ipynb
@@ -54,18 +54,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/simulators/simulators_sample.ipynb
+++ b/notebooks/simulators/simulators_sample.ipynb
@@ -41,18 +41,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {

--- a/notebooks/simulators/util.ipynb
+++ b/notebooks/simulators/util.ipynb
@@ -23,18 +23,19 @@
    "source": [
     "try:\n",
     "    import google.colab\n",
+    "except ImportError:\n",
+    "    from autofit import setup_colab as _setup_colab\n",
+    "else:\n",
+    "    import importlib\n",
     "    import subprocess\n",
     "    import sys\n",
     "\n",
     "    subprocess.check_call(\n",
     "        [sys.executable, \"-m\", \"pip\", \"install\", \"autonerves\", \"--no-deps\"]\n",
     "    )\n",
-    "except ImportError:\n",
-    "    pass\n",
+    "    _setup_colab = importlib.import_module(\"autonerves.setup_colab\")\n",
     "\n",
-    "from autonerves import setup_colab\n",
-    "\n",
-    "setup_colab.setup(\"autofit\")"
+    "_setup_colab.setup(\"autofit\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
Regenerate PyAutoFit examples so Colab setup is exposed through the public `autofit` API. Fresh Colab sessions still install `autonerves` and load its backend privately.

## Scripts Changed
- No handwritten scripts changed; generated notebooks now use the shared private Colab bootstrap emitted by merged PyAutoHands.
- `notebooks/**/*.ipynb` — regenerate setup cells with the AutoFit project mapping.

## Test Plan
- [x] Workspace generation and generated-artifact checks pass.
- [x] Targeted AutoFit smoke checks pass.
- [x] No direct `from autonerves import setup_colab` import remains.

Generated by the PyAutoLabs agent workflow.
