### PR TITLE
docs: merge adjacent documentation blocks

### DIFF
--- a/notebooks/cookbooks/analysis.ipynb
+++ b/notebooks/cookbooks/analysis.ipynb
@@ -598,20 +598,8 @@
     "#         plt.title(\"Live max-likelihood fit\")\n",
     "#         plt.savefig(path.join(paths.image_path, \"fit.png\"))\n",
     "#         plt.clf()\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "```\n",
+    "\n",
     "__Custom Result__\n",
     "\n",
     "The `Result` object is returned by a non-linear search after running the following code:\n",
@@ -1026,13 +1014,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/configs.ipynb
+++ b/notebooks/cookbooks/configs.ipynb
@@ -394,13 +394,6 @@
     "    parameter2: '{:.2f}'\n",
     "    rate: '{:.2f}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/latent_variables.ipynb
+++ b/notebooks/cookbooks/latent_variables.ipynb
@@ -158,16 +158,8 @@
     "sample.\n",
     "\n",
     "The same trick generalises. Whenever a quantity you care about is a function of the parameters but not part of\n",
-    "the likelihood, it can be a latent variable."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
+    "the likelihood, it can be a latent variable.\n",
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Why Latent Variables?__\n",
     "\n",
     "Three common motivating cases:\n",
@@ -189,18 +181,7 @@
     "\n",
     "Because latent variables are computed *after* the search completes, they cost zero per-likelihood evaluation \u2014\n",
     "adding one never slows the fit down.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "\n",
-    "# %%\n",
-    "'''\n",
     "__How PyAutoFit Computes Latents__\n",
     "\n",
     "A model declares its latent variables with a `Latent` class (subclass of `af.Latent`), attached to the\n",
@@ -218,18 +199,7 @@
     "The method is called *after* the search completes. It is never invoked inside `log_likelihood_function`, so\n",
     "latent computations cannot influence which models the search prefers \u2014 they only attach extra information to\n",
     "samples that have already been drawn.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Two Output Modes__\n",
     "\n",
     "PyAutoFit supports two strategies for computing latent values after a fit, controlled by `output.yaml`. Both\n",
@@ -257,18 +227,7 @@
     "\n",
     "For most use cases the defaults are right: latents are computed once at the end, only summary statistics are\n",
     "written, and you opt into every-sample mode when you specifically need it.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Errors on Latents__\n",
     "\n",
     "This is the most important concept in the cookbook, and the most commonly misunderstood. The 1\u03c3 and 3\u03c3 intervals\n",
@@ -291,11 +250,8 @@
     "badly misleading. Latents always do it the honest way.\n",
     "\n",
     "We can read the latent's 1\u03c3 interval back out via the same `Samples` API used for parameters. First, materialise\n",
-    "the latent samples from the fit result, then query them just like a regular `Samples` object:\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "the latent samples from the fit result, then query them just like a regular `Samples` object:"
+   ]
   },
   {
    "cell_type": "code",
@@ -318,16 +274,8 @@
    "source": [
     "The intervals are asymmetric whenever the underlying parameter posterior is asymmetric \u2014 for instance, when the\n",
     "prior on `\u03c3` is bounded near zero. The 1\u03c3 interval is a pair `(lower, upper)` with no requirement that\n",
-    "`upper - median == median - lower`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
+    "`upper - median == median - lower`.\n",
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Posterior Draws Under the Hood__\n",
     "\n",
     "`analysis.compute_latent_samples(result.samples)` does mechanically what the explanation above describes:\n",
@@ -346,18 +294,7 @@
     "If the latent computation itself is expensive (e.g. a multi-band lensing integral), the cost is what dominates,\n",
     "not the dispatch loop. In that regime the N-draws-from-PDF mode is dramatically faster than every-sample mode\n",
     "and almost always sufficient for reporting.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Loading Results Downstream__\n",
     "\n",
     "Once a fit has produced latent output, you can access it in two ways.\n",
@@ -382,18 +319,7 @@
     "The committed `latent.csv` file format is intentionally human-readable \u2014 one column per latent key,\n",
     "one row per sample (or per posterior draw, in N-draws mode), plus the standard `log_likelihood`, `log_prior`,\n",
     "and `weight` columns. You can open it in any spreadsheet tool for a quick visual check.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "\n",
-    "# %%\n",
-    "'''\n",
     "__When To Add A Latent vs A Sampled Parameter__\n",
     "\n",
     "A short rule of thumb:\n",
@@ -412,18 +338,8 @@
     "\n",
     "Latent variables shine when downstream consumers (your collaborators, your readers, your aggregator pipelines)\n",
     "need to compare across many fits. A single latent column in `latent.csv` makes that comparison trivial; deriving\n",
-    "the same quantity by hand from `samples.csv` is error-prone and verbose.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
+    "the same quantity by hand from `samples.csv` is error-prone and verbose."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/model.ipynb
+++ b/notebooks/cookbooks/model.ipynb
@@ -1468,13 +1468,6 @@
     "Advanced model composition uses multi-level models, which compose models from hierarchies of Python classes. This is\n",
     "described in the multi-level model cookbook. "
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/model_internal.ipynb
+++ b/notebooks/cookbooks/model_internal.ipynb
@@ -1022,24 +1022,13 @@
    "metadata": {},
    "source": [
     "Linked priors are preserved through serialization. If two parameters shared the same prior before saving,\n",
-    "they will share the same prior after loading."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
+    "they will share the same prior after loading.\n",
     "\n",
-    "# %%\n",
-    "'''\n",
     "__Log Prior Computation__\n",
     "\n",
     "During MCMC sampling (e.g. with emcee), the log prior probability for a parameter vector is needed. The model\n",
-    "provides this directly:\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "provides this directly:"
+   ]
   },
   {
    "cell_type": "code",
@@ -1266,13 +1255,6 @@
     "is built upon. They are particularly useful when building custom search integrations, analysis pipelines, or\n",
     "debugging model-fitting workflows."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/multi_level_model.ipynb
+++ b/notebooks/cookbooks/multi_level_model.ipynb
@@ -604,13 +604,6 @@
     "You should think carefully about whether your model fitting problem can use multi-level models, as they can make\n",
     "your model definition more concise and extensible."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/multiple_datasets.ipynb
+++ b/notebooks/cookbooks/multiple_datasets.ipynb
@@ -771,13 +771,6 @@
     "We have shown how **PyAutoFit** can fit large datasets simultaneously, using custom models that vary specific\n",
     "parameters across the dataset."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/result.ipynb
+++ b/notebooks/cookbooks/result.ipynb
@@ -1104,13 +1104,6 @@
     "\n",
     "Once we have the Aggregator, we can use it to query the database and load results as we did before."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -950,13 +950,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/expectation_propagation.ipynb
+++ b/notebooks/features/expectation_propagation.ipynb
@@ -552,13 +552,6 @@
     " - **HowToFit** chapter 3 (`scripts/chapter_3_graphical_models/`) \u2014 the full tutorial series, including hierarchical\n",
     "   models where shared parameters are drawn from a parent distribution, and EP fits of those hierarchies."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/graphical_models.ipynb
+++ b/notebooks/features/graphical_models.ipynb
@@ -427,13 +427,6 @@
     "\n",
     "Hierarchical models can also be scaled up to large datasets via Expectation Propagation."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -458,13 +458,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/model_comparison.ipynb
+++ b/notebooks/features/model_comparison.ipynb
@@ -672,13 +672,6 @@
     "\n",
     "Discuss Priors. Discuss unique id and benefits of autofit / science workflow."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/search_chaining.ipynb
+++ b/notebooks/features/search_chaining.ipynb
@@ -681,16 +681,8 @@
     "and sigma=2.0.\n",
     "\n",
     "And with that, we`re done. Chaining searches is a bit of an art form, but for certain problems can be extremely \n",
-    "powerful."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
+    "powerful.\n",
     "\n",
-    "# %%\n",
-    "'''\n",
     "Cookbook 5: Model Linking\n",
     "=========================\n",
     "\n",
@@ -706,11 +698,8 @@
     "To perform search chaining, **PyAutoFit** has tools for passing the results of one model-fit from one fit to the next,\n",
     "and change its parameterization between each fit.\n",
     "\n",
-    "This cookbook is a concise reference to the model linking API.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "This cookbook is a concise reference to the model linking API."
+   ]
   },
   {
    "cell_type": "code",

--- a/notebooks/features/search_grid_search.ipynb
+++ b/notebooks/features/search_grid_search.ipynb
@@ -568,13 +568,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -803,13 +803,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/features/shared_analysis_state.ipynb
+++ b/notebooks/features/shared_analysis_state.ipynb
@@ -363,13 +363,6 @@
     "general) when the shared work is genuinely identical across every factor. When only some parameters are shared, as in\n",
     "`graphical_models.py`, leave it off and let each factor compute its own state."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/overview/overview_1_the_basics.ipynb
+++ b/notebooks/overview/overview_1_the_basics.ipynb
@@ -1345,13 +1345,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/overview/overview_2_scientific_workflow.ipynb
+++ b/notebooks/overview/overview_2_scientific_workflow.ipynb
@@ -889,13 +889,6 @@
     "inference methods available in **PyAutoFit**. These methods include graphical models, hierarchical models,\n",
     "Bayesian model comparison and many more."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/overview/overview_3_statistical_methods.ipynb
+++ b/notebooks/overview/overview_3_statistical_methods.ipynb
@@ -166,13 +166,6 @@
     "\n",
     "_setup_colab.setup(\"autofit\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/plot/dynesty_plotter.ipynb
+++ b/notebooks/plot/dynesty_plotter.ipynb
@@ -165,20 +165,10 @@
     " - Set the fontsize of the title by passing `title_kwargs={\"fontsize\": \"10\"}`.\n",
     "\n",
     "There are other `_kwargs` inputs we pass as None, you should check out the Dynesty docs if you need to customize your\n",
-    "figure."
+    "figure.\n",
+    "\n",
+    "The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "# %%\n",
-    "'''\n",
-    "The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -531,13 +521,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/plot/emcee_plotter.ipynb
+++ b/notebooks/plot/emcee_plotter.ipynb
@@ -335,13 +335,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/plot/get_dist.ipynb
+++ b/notebooks/plot/get_dist.ipynb
@@ -451,13 +451,6 @@
     "\n",
     "GetDist will clever use the `names` of the parameters to combine the parameters into customizeable PDF plots."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/plot/nautilus_plotter.ipynb
+++ b/notebooks/plot/nautilus_plotter.ipynb
@@ -168,20 +168,10 @@
     " - Set the fontsize of the title by passing `title_kwargs={\"fontsize\": \"10\"}`.\n",
     "\n",
     "There are other `_kwargs` inputs we pass as None, you should check out the Nautilus docs if you need to customize your\n",
-    "figure."
+    "figure.\n",
+    "\n",
+    "The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "# %%\n",
-    "'''\n",
-    "The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -256,13 +246,6 @@
     "\n",
     "Nautilus example plots are not shown explicitly below, so checkout their docs for examples!"
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/plot/zeus_plotter.ipynb
+++ b/notebooks/plot/zeus_plotter.ipynb
@@ -165,20 +165,10 @@
     "- https://corner.readthedocs.io/en/latest/index.html\n",
     "\n",
     "In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are\n",
-    "described in the API docs."
+    "described in the API docs.\n",
+    "\n",
+    "The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter using the library `corner.py`."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "# %%\n",
-    "'''\n",
-    "The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter using the library `corner.py`.\n",
-    "'''"
-   ],
-   "outputs": [],
-   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -318,13 +308,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/searches/start_point.ipynb
+++ b/notebooks/searches/start_point.ipynb
@@ -341,13 +341,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/notebooks/simulators/simulators.ipynb
+++ b/notebooks/simulators/simulators.ipynb
@@ -459,13 +459,6 @@
    "source": [
     "Finish."
    ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [],
-   "outputs": [],
-   "execution_count": null
   }
  ],
  "metadata": {

--- a/scripts/cookbooks/analysis.py
+++ b/scripts/cookbooks/analysis.py
@@ -472,10 +472,7 @@ visual every `iterations_per_quick_update` evaluations, and declares itself thre
 #         plt.savefig(path.join(paths.image_path, "fit.png"))
 #         plt.clf()
 ```
-"""
 
-
-"""
 __Custom Result__
 
 The `Result` object is returned by a non-linear search after running the following code:

--- a/scripts/cookbooks/latent_variables.py
+++ b/scripts/cookbooks/latent_variables.py
@@ -94,9 +94,7 @@ sample.
 
 The same trick generalises. Whenever a quantity you care about is a function of the parameters but not part of
 the likelihood, it can be a latent variable.
-"""
 
-"""
 __Why Latent Variables?__
 
 Three common motivating cases:
@@ -118,9 +116,7 @@ Three common motivating cases:
 
 Because latent variables are computed *after* the search completes, they cost zero per-likelihood evaluation —
 adding one never slows the fit down.
-"""
 
-"""
 __How PyAutoFit Computes Latents__
 
 A model declares its latent variables with a `Latent` class (subclass of `af.Latent`), attached to the
@@ -138,9 +134,7 @@ that drives the dispatch is at `PyAutoFit/autofit/non_linear/analysis/latent.py`
 The method is called *after* the search completes. It is never invoked inside `log_likelihood_function`, so
 latent computations cannot influence which models the search prefers — they only attach extra information to
 samples that have already been drawn.
-"""
 
-"""
 __Two Output Modes__
 
 PyAutoFit supports two strategies for computing latent values after a fit, controlled by `output.yaml`. Both
@@ -168,9 +162,7 @@ Two further flags toggle whether latents are computed at all:
 
 For most use cases the defaults are right: latents are computed once at the end, only summary statistics are
 written, and you opt into every-sample mode when you specifically need it.
-"""
 
-"""
 __Errors on Latents__
 
 This is the most important concept in the cookbook, and the most commonly misunderstood. The 1σ and 3σ intervals
@@ -207,9 +199,7 @@ print(f"Max log-likelihood FWHM: {max_likelihood_instance.gaussian.fwhm}")
 The intervals are asymmetric whenever the underlying parameter posterior is asymmetric — for instance, when the
 prior on `σ` is bounded near zero. The 1σ interval is a pair `(lower, upper)` with no requirement that
 `upper - median == median - lower`.
-"""
 
-"""
 __Posterior Draws Under the Hood__
 
 `analysis.compute_latent_samples(result.samples)` does mechanically what the explanation above describes:
@@ -228,9 +218,7 @@ the search runs under JAX.
 If the latent computation itself is expensive (e.g. a multi-band lensing integral), the cost is what dominates,
 not the dispatch loop. In that regime the N-draws-from-PDF mode is dramatically faster than every-sample mode
 and almost always sufficient for reporting.
-"""
 
-"""
 __Loading Results Downstream__
 
 Once a fit has produced latent output, you can access it in two ways.
@@ -255,9 +243,7 @@ also surfaces them for batched analysis across many fits. The end-to-end loading
 The committed `latent.csv` file format is intentionally human-readable — one column per latent key,
 one row per sample (or per posterior draw, in N-draws mode), plus the standard `log_likelihood`, `log_prior`,
 and `weight` columns. You can open it in any spreadsheet tool for a quick visual check.
-"""
 
-"""
 __When To Add A Latent vs A Sampled Parameter__
 
 A short rule of thumb:

--- a/scripts/cookbooks/model_internal.py
+++ b/scripts/cookbooks/model_internal.py
@@ -453,9 +453,7 @@ print(f"Loaded model prior count: {loaded_model.prior_count}")
 """
 Linked priors are preserved through serialization. If two parameters shared the same prior before saving,
 they will share the same prior after loading.
-"""
 
-"""
 __Log Prior Computation__
 
 During MCMC sampling (e.g. with emcee), the log prior probability for a parameter vector is needed. The model

--- a/scripts/features/search_chaining.py
+++ b/scripts/features/search_chaining.py
@@ -419,9 +419,7 @@ and sigma=2.0.
 
 And with that, we`re done. Chaining searches is a bit of an art form, but for certain problems can be extremely 
 powerful.
-"""
 
-"""
 Cookbook 5: Model Linking
 =========================
 

--- a/scripts/plot/dynesty_plotter.py
+++ b/scripts/plot/dynesty_plotter.py
@@ -90,8 +90,7 @@ we:
 
 There are other `_kwargs` inputs we pass as None, you should check out the Dynesty docs if you need to customize your
 figure.
-"""
-"""
+
 The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.
 """
 aplt.corner_anesthetic(samples=samples)

--- a/scripts/plot/nautilus_plotter.py
+++ b/scripts/plot/nautilus_plotter.py
@@ -93,8 +93,7 @@ we:
 
 There are other `_kwargs` inputs we pass as None, you should check out the Nautilus docs if you need to customize your
 figure.
-"""
-"""
+
 The `corner_anesthetic` function produces a triangle of 1D and 2D PDF's of every parameter using the library `anesthetic`.
 """
 aplt.corner_anesthetic(samples=samples)

--- a/scripts/plot/zeus_plotter.py
+++ b/scripts/plot/zeus_plotter.py
@@ -90,8 +90,7 @@ The `aplt.corner_cornerpy` function wraps the library `corner.py` to make corner
 
 In all the examples below, we use the `kwargs` of this function to pass in any of the input parameters that are
 described in the API docs.
-"""
-"""
+
 The `corner_cornerpy` function produces a triangle of 1D and 2D PDF's of every parameter using the library `corner.py`.
 """
 aplt.corner_cornerpy(


### PR DESCRIPTION
## Summary
- Merges 13 scanner-confirmed adjacent top-level documentation boundaries across seven PyAutoFit workspace scripts.
- Preserves every decoded prose block and its ordering exactly while removing empty notebook-conversion boundaries.
- Contributes to the workspace-wide cleanup tracked by PyAutoLabs/autolens_workspace#341; detection is in PyAutoBrain PR #163 and generator hardening is in PyAutoHands PR #197.

## Scripts Changed
- `scripts/cookbooks/analysis.py` — joined adjacent custom-analysis/result documentation.
- `scripts/cookbooks/latent_variables.py` — joined the eight-block latent-variable documentation chain.
- `scripts/cookbooks/model_internal.py` — joined adjacent serialization and log-prior documentation.
- `scripts/features/search_chaining.py` — joined the adjacent chaining and model-linking sections.
- `scripts/plot/dynesty_plotter.py` — joined adjacent plotting documentation.
- `scripts/plot/nautilus_plotter.py` — joined adjacent plotting documentation.
- `scripts/plot/zeus_plotter.py` — joined adjacent plotting documentation.

## Generated Artifacts
- Regenerated notebooks and the workspace navigator catalogue from the updated scripts.

## Test Plan
- [x] Exact origin/main transform witnesses and Python compilation passed for all seven scripts.
- [x] Canonical workspace smoke runner passed 10/10 entries.
- [x] Seven generated notebook conversions contain no column-zero marker or triple-quote artifact code cells.
- [x] Workspace-wide Hygiene scan reports zero findings and zero parse errors.

## Could not update
- None.

Generated by the PyAutoLabs agent workflow.
