### PR TITLE
ci: adopt the notebook SystemExit(0) skip-guard classifier (PyAutoHands#198)

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -55,6 +55,8 @@ except ImportError:  # pragma: no cover - local-run fallback
     sys.path.insert(0, str(WORKSPACE.parent / "PyAutoHands" / "autohands"))
     from env_config import build_env_for_script, load_env_config
 
+from build_util import is_clean_skip_exit  # PyAutoHands/autohands on PYTHONPATH
+
 
 def load_lines(path: Path) -> list[str]:
     if not path.exists():
@@ -167,6 +169,10 @@ def run_notebook(nb_rel: str, cfg: dict | None) -> tuple[str, int, float, str]:
         return nb_rel, 1, 0.0, f"Notebook not found: {nb_path}\n"
 
     rc, output = execute_notebook(nb_path, env)
+    if rc != 0 and is_clean_skip_exit(output):
+        # Optional-dependency skip guard (`sys.exit(0)`): a clean exit 0 as a
+        # `.py` script, so the notebook form is a PASS too (PyAutoHands#198).
+        rc = 0
     if rc == 0:
         return nb_rel, 0, time.time() - t0, output
 


### PR DESCRIPTION
Rolls the PyAutoHands#198 adoption into this repo's `run_smoke.py` copy: notebooks that exit via the optional-dependency skip guard (`sys.exit(0)` — e.g. `searches/mcmc.ipynb` without blackjax) now PASS instead of erroring the cell, matching the `.py` semantics. Two-line change importing `build_util.is_clean_skip_exit` (PyAutoHands is already on PYTHONPATH here); the skip check short-circuits ahead of the regenerate-and-retry path; nonzero exits and real errors still FAIL (verified end-to-end with throwaway pass/fail notebooks through this repo's own `run_notebook`).

Note: of the nine run_smoke.py copies, only the three user-facing workspaces (autofit/autolens/autogalaxy) have a notebook leg — sibling PRs land the same change there; the HowTo and `*_test` runners are scripts-only and need nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzN9PZfG5zXMVku8ckSqkC)_