### PR TITLE
docs: fix dead internal references in script docstrings

### DIFF
--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -458,7 +458,7 @@
     "\n",
     "This fit used `Emcee` therefore we use `corner.py` for visualization via the `aplt.corner_cornerpy` function.\n",
     "\n",
-    "The `autofit_workspace/*/plots` folder illustrates other packages that can be used to make these plots using\n",
+    "The `autofit_workspace/*/plot` folder illustrates other packages that can be used to make these plots using\n",
     "the standard output results formats (e.g. `get_dist.py`)."
    ]
   },
@@ -680,7 +680,7 @@
     "\n",
     "By combining this with the filtering tools below, specific parameters can be included or removed from the latex.\n",
     "\n",
-    "Remember that the superscripts of a parameter are loaded from the config file `notation/label.yaml`, providing high\n",
+    "Remember that the superscripts of a parameter are loaded from the config file `notation.yaml`, providing high\n",
     "levels of customization for how the parameter names appear in the latex table. This is especially useful if your model\n",
     "uses the same model components with the same parameter, which therefore need to be distinguished via superscripts."
    ]

--- a/scripts/cookbooks/samples.py
+++ b/scripts/cookbooks/samples.py
@@ -272,7 +272,7 @@ visualization tools.
 
 This fit used `Emcee` therefore we use `corner.py` for visualization via the `aplt.corner_cornerpy` function.
 
-The `autofit_workspace/*/plots` folder illustrates other packages that can be used to make these plots using
+The `autofit_workspace/*/plot` folder illustrates other packages that can be used to make these plots using
 the standard output results formats (e.g. `get_dist.py`).
 """
 aplt.corner_cornerpy(samples=result.samples)
@@ -395,7 +395,7 @@ you can copy to your .tex document.
 
 By combining this with the filtering tools below, specific parameters can be included or removed from the latex.
 
-Remember that the superscripts of a parameter are loaded from the config file `notation/label.yaml`, providing high
+Remember that the superscripts of a parameter are loaded from the config file `notation.yaml`, providing high
 levels of customization for how the parameter names appear in the latex table. This is especially useful if your model
 uses the same model components with the same parameter, which therefore need to be distinguished via superscripts.
 """


### PR DESCRIPTION
Part of PyAutoLabs/autolens_workspace#377, which tracks this sweep across all 7 repos.

## Summary

The README half of this drift class is fixed and now gated at PR time (PyAutoHands#213). This is the remaining surface: **dead file/folder references in `scripts/**/*.py` docstrings and comments** — the same restructure debt, in prose the gate deliberately does not cover.

Driven by `pyauto-brain hygiene refs --json`, which reported **129 findings across 7 repos**.

## Scripts Changed

Docstring/comment prose only — no code, no API, no behaviour. Notebooks and the navigator catalogue are regenerated, since docstring text feeds `notebooks/`, `llms-full.txt` and `workspace_index.json`.

**Verified re-points (113):**
- `log_likelihood_function` → `likelihood_function` — the scripts drop the `log_` prefix
- `notation/label.yaml` → `notation.yaml` — the config went from a folder to a file
- `config/generag.yaml` → `config/general.yaml` — autolens→autogalaxy clone residue, here in script prose
- `autofit_workspace/*/plots` → `plot` — the package is singular
- `feature/pixelization/…` → `features/…`; `subhalo/detection` → `subhalo/detect`
- `guides/source_science` → the topic packages (`source_science.py` lives in `imaging/`, `interferometer/`, `group/` — never `guides/`)
- `preprocess` / `propocess` → `imaging/data_preparation`
- `modeling/imaging/{customize,searches}` → `guides/modeling/…`; `imaging/advanced/database` → `guides/results/database`
- `simulators` → `simulator` (singular)
- **dataset directories quoted without their `dataset/` prefix** — the folder is written by a simulator, so the fix is qualification, not a restore

**Eleven needed prose rewriting**, because the target does not exist in any form:
- autogalaxy has no CPU-fast pixelization example → now references the autolens one explicitly
- `point_source` has no likelihood-function walkthrough → points at `cluster/likelihood_function`, which is literally titled *"Log Likelihood Function: Cluster Point Source"*
- no `subhalo/detect/examples` folder exists anywhere → dead sentence removed
- `mat_wrap.yaml` was retired in favour of `general.yaml`
- `config/priors` has no `default` subfolder
- `z_projects/` is not part of this workspace → the Euclid pipeline has its own repo

## Validation

- `hygiene refs`: **129 → 0** findings across all 7 repos.
- `check_navigator.py --banners=fail`: **PASS** on all 6 gated repos.
- Two of my own re-points were wrong and caught by re-running the scanner: I had mapped `point_source/log_likelihood_function` → `point_source/likelihood_function` and `subhalo/detection/examples` → `subhalo/detect/examples`, but neither target exists. Both re-fixed above.

## Known gap

`autocti_workspace` notebooks are **not** regenerated. `generate.py` rejects the `autocti` project — it is absent from `COLAB_PROJECTS` and from PyAutoNerves's `_PROJECTS` registry. Attempting it deletes the `notebooks/` tree and aborts (restored here; no damage in this branch). The 5 script fixes stand; that repo's notebooks stay as they were. Filing a follow-up to register `autocti`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
