### PR TITLE
docs: remove the Finished./Finish. notebook-generation crutch

### DIFF
--- a/markdown/overview/overview_1_the_basics.md
+++ b/markdown/overview/overview_1_the_basics.md
@@ -2773,11 +2773,3 @@ plt.close()
     
 ![png](overview_1_the_basics_files/overview_1_the_basics_77_0.png)
     
-
-
-Finish.
-
-
-```python
-
-```

--- a/notebooks/cookbooks/analysis.ipynb
+++ b/notebooks/cookbooks/analysis.ipynb
@@ -1007,13 +1007,6 @@
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -939,17 +939,10 @@
     "print(\n",
     "    \"All parameters of the very first sample (containing only the Gaussian normalization and sigma).\"\n",
     ")\n",
-    "print(samples.parameter_lists[0])"
+    "print(samples.parameter_lists[0])\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -448,17 +448,10 @@
     "    f\"Gaussian centre of fit at t = 2: {instance_at_time(ml_instances_list, 2).gaussian.centre}\"\n",
     ")\n",
     "\n",
-    "print(f\"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}\")"
+    "print(f\"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}\")\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/features/search_grid_search.ipynb
+++ b/notebooks/features/search_grid_search.ipynb
@@ -557,17 +557,10 @@
     "#     model=model,\n",
     "#     analysis=analysis,\n",
     "#     grid_priors=[model.gaussian_feature.centre, model.gaussian_main.centre],\n",
-    "# )"
+    "# )\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -792,17 +792,10 @@
    "metadata": {},
    "source": [
     "print(sensitivity_result.samples)\n",
-    "print(sensitivity_result.log_evidences_base)"
+    "print(sensitivity_result.log_evidences_base)\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/overview/overview_1_the_basics.ipynb
+++ b/notebooks/overview/overview_1_the_basics.ipynb
@@ -1334,17 +1334,10 @@
     "plt.xlabel(\"x values of profile\")\n",
     "plt.ylabel(\"Profile normalization\")\n",
     "plt.show()\n",
-    "plt.close()"
+    "plt.close()\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/plot/dynesty_plotter.ipynb
+++ b/notebooks/plot/dynesty_plotter.ipynb
@@ -510,17 +510,10 @@
     "    plt.close()\n",
     "\n",
     "except ValueError:\n",
-    "    pass"
+    "    pass\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/plot/emcee_plotter.ipynb
+++ b/notebooks/plot/emcee_plotter.ipynb
@@ -324,17 +324,10 @@
     "\n",
     "axes[-1].set_xlabel(\"step number\")\n",
     "\n",
-    "plt.show()"
+    "plt.show()\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/plot/zeus_plotter.ipynb
+++ b/notebooks/plot/zeus_plotter.ipynb
@@ -297,17 +297,10 @@
     "\n",
     "axes[-1].set_xlabel(\"step number\")\n",
     "\n",
-    "plt.show()"
+    "plt.show()\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/searches/start_point.ipynb
+++ b/notebooks/searches/start_point.ipynb
@@ -330,17 +330,10 @@
     "\n",
     "print(samples.parameter_lists[0])\n",
     "print(samples.parameter_lists[1])\n",
-    "print(samples.parameter_lists[2])"
+    "print(samples.parameter_lists[2])\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/notebooks/simulators/simulators.ipynb
+++ b/notebooks/simulators/simulators.ipynb
@@ -448,17 +448,10 @@
     "\n",
     "dataset_path = path.join(\"dataset\", \"example_1d\", \"gaussian_x1_variable\", \"sigma_2\")\n",
     "gaussian = af.ex.Gaussian(centre=50.0, normalization=50.0, sigma=30.0)\n",
-    "util.simulate_dataset_1d_via_gaussian_from(gaussian=gaussian, dataset_path=dataset_path)"
+    "util.simulate_dataset_1d_via_gaussian_from(gaussian=gaussian, dataset_path=dataset_path)\n"
    ],
    "outputs": [],
    "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finish."
-   ]
   }
  ],
  "metadata": {

--- a/scripts/cookbooks/analysis.py
+++ b/scripts/cookbooks/analysis.py
@@ -820,8 +820,3 @@ class Analysis(af.Analysis):
 
         with open(file_path, "w+") as f:
             json.dump(model_data, f, indent=4)
-
-
-"""
-Finish.
-"""

--- a/scripts/cookbooks/samples.py
+++ b/scripts/cookbooks/samples.py
@@ -584,7 +584,3 @@ print(
     "All parameters of the very first sample (containing only the Gaussian normalization and sigma)."
 )
 print(samples.parameter_lists[0])
-
-"""
-Finish.
-"""

--- a/scripts/features/interpolate.py
+++ b/scripts/features/interpolate.py
@@ -294,7 +294,3 @@ print(
 )
 
 print(f"Gaussian centre interpolated at t = 1.5 {instance.gaussian.centre}")
-
-"""
-Finish.
-"""

--- a/scripts/features/search_grid_search.py
+++ b/scripts/features/search_grid_search.py
@@ -334,7 +334,3 @@ time to run, so I've commented it out, but feel free to run it!
 #     analysis=analysis,
 #     grid_priors=[model.gaussian_feature.centre, model.gaussian_main.centre],
 # )
-
-"""
-Finish.
-"""

--- a/scripts/features/sensitivity_mapping.py
+++ b/scripts/features/sensitivity_mapping.py
@@ -573,7 +573,3 @@ of results. If you intend to use sensitivity mapping, the best way to interpret 
 """
 print(sensitivity_result.samples)
 print(sensitivity_result.log_evidences_base)
-
-"""
-Finish.
-"""

--- a/scripts/overview/overview_1_the_basics.py
+++ b/scripts/overview/overview_1_the_basics.py
@@ -873,7 +873,3 @@ plt.xlabel("x values of profile")
 plt.ylabel("Profile normalization")
 plt.show()
 plt.close()
-
-"""
-Finish.
-"""

--- a/scripts/plot/dynesty_plotter.py
+++ b/scripts/plot/dynesty_plotter.py
@@ -333,7 +333,3 @@ try:
 
 except ValueError:
     pass
-
-"""
-Finish.
-"""

--- a/scripts/plot/emcee_plotter.py
+++ b/scripts/plot/emcee_plotter.py
@@ -189,7 +189,3 @@ for i in range(result.samples.model.prior_count):
 axes[-1].set_xlabel("step number")
 
 plt.show()
-
-"""
-Finish.
-"""

--- a/scripts/plot/zeus_plotter.py
+++ b/scripts/plot/zeus_plotter.py
@@ -174,7 +174,3 @@ for i in range(result.samples.model.prior_count):
 axes[-1].set_xlabel("step number")
 
 plt.show()
-
-"""
-Finish.
-"""

--- a/scripts/searches/start_point.py
+++ b/scripts/searches/start_point.py
@@ -186,7 +186,3 @@ print(samples.model.parameter_names)
 print(samples.parameter_lists[0])
 print(samples.parameter_lists[1])
 print(samples.parameter_lists[2])
-
-"""
-Finish.
-"""

--- a/scripts/simulators/simulators.py
+++ b/scripts/simulators/simulators.py
@@ -205,7 +205,3 @@ util.simulate_dataset_1d_via_gaussian_from(gaussian=gaussian, dataset_path=datas
 dataset_path = path.join("dataset", "example_1d", "gaussian_x1_variable", "sigma_2")
 gaussian = af.ex.Gaussian(centre=50.0, normalization=50.0, sigma=30.0)
 util.simulate_dataset_1d_via_gaussian_from(gaussian=gaussian, dataset_path=dataset_path)
-
-"""
-Finish.
-"""


### PR DESCRIPTION
Removes the `Finished.` / `Finish.` notebook-generation crutch from `autofit_workspace` — **11 occurrences**: 11 trailing blocks.

Artifacts: 11 notebooks regenerated; 1 `markdown/` page.


## Why

These trailing docstring blocks were a crutch against notebook generation "cutting off weird" when a script's last cell was not a docstring. That belief is obsolete: deleting the block and running the real `add_notebook_quotes` → `ipynb-py-convert` chain gives a complete, unmangled final code cell, and PyAutoLabs/PyAutoHands#214 adds `test_script_ending_in_code_keeps_a_complete_final_code_cell` to pin it. The crutch rendered as a pointless final markdown cell in every generated notebook.

## Shapes handled

A blanket regex would be wrong — five distinct shapes exist and each needs different handling. The sweep used Python's own `tokenize` to locate the exact string token each occurrence lives in, because a line-based scanner cannot tell a narrative docstring's bare delimiter from a function docstring that opens with text on the delimiter line, and this corpus contains both.

## Verification

- Every changed file compiles.
- `black --check` clean.
- **Env declarations byte-identical before and after.** Removing the word above an `__Env__` section turns the canonical merged form into the standalone-fallback form; both are supported. Checked by running `env_config.read_env_declaration` on the old and new content of all 169 changed files across the series: **169 unchanged, 0 changed, 0 errors**.
- **CRLF preserved.** Several of these repos ship CRLF `.py` files; the first attempt normalised them and rewrote whole files (~6000 line churn). The sweep reads and writes with `newline=""`, so the diff is deletions only.
- No generated notebook contains a code cell with a literal `# %%` or `'''`, and no notebook has a `Finish.` markdown cell.

## Merge order

**PyAutoLabs/PyAutoHands#214 merges first** — this repo invokes `../PyAutoHands/autohands/generate.py` from the local checkout, so the regenerated notebooks here are only correct against that version.

Part of PyAutoLabs/PyAutoHands#211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XzXdQMU3KV2tyZaMNPvsM