### PR TITLE
CI: one run per commit (push builds main only)

### DIFF
--- a/.github/workflows/navigator_check.yml
+++ b/.github/workflows/navigator_check.yml
@@ -5,8 +5,18 @@ name: Navigator Check
 # PyAutoHands/autohands; this workspace only declares which generator project to
 # run. See PyAutoLabs/PyAutoHands/.github/workflows/navigator_check.yml.
 
-on: [push, pull_request]
+# One run per commit: PR events carry the CI; pushes only build main
+# (Heart's ws_ci gate reads main-HEAD conclusions). Superseded runs are
+# cancelled on PR refs only — a cancelled main run would read as red CI
+# (cancelled is in Heart's FAILURE_CONCLUSIONS).
+on:
+  push:
+    branches: [main]
+  pull_request:
 
+concurrency:
+  group: navigator_check-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 permissions:
   contents: read
 

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -5,8 +5,18 @@ name: Smoke Tests
 # workspace declares its dependency chain and owns its install epilogue
 # (.github/scripts/smoke_install.sh) and runner (.github/scripts/run_smoke.py).
 
-on: [push, pull_request]
+# One run per commit: PR events carry the CI; pushes only build main
+# (Heart's ws_ci gate reads main-HEAD conclusions). Superseded runs are
+# cancelled on PR refs only — a cancelled main run would read as red CI
+# (cancelled is in Heart's FAILURE_CONCLUSIONS).
+on:
+  push:
+    branches: [main]
+  pull_request:
 
+concurrency:
+  group: smoke_tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 jobs:
   smoke:
     uses: PyAutoLabs/PyAutoHeart/.github/workflows/smoke-tests.yml@main


### PR DESCRIPTION
Part of PyAutoLabs/PyAutoHeart#130 (fleet CI dedupe — every PR's checks currently run twice).

Mechanical: `on: [push, pull_request]` → `push: branches: [main]` + `pull_request`, plus a `concurrency` group with `cancel-in-progress` on non-main refs only (a cancelled main run would read as red CI to Heart). Post-merge main runs preserved. Trade-off: a branch pushed with no open PR gets no CI until its PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)