### PR TITLE
fix: park EP script as NEEDS_FIX no_run for release testing

### DIFF
--- a/config/build/no_run.yaml
+++ b/config/build/no_run.yaml
@@ -23,3 +23,4 @@
 - zeus_plotter # Test Model Iniitalization no good.
 - dynesty_plotter # Test Model Iniitalization no good.
 - start_point # bug https://github.com/rhayes777/PyAutoFit/issues/1017
+- features/expectation_propagation.py # NEEDS_FIX 2026-08-03 - EP parked as not release-ready. EP message projection is unstable: a truncated per-factor search projects an ESS=1 posterior with zero weighted variance, which EP feeds back as a delta-function prior. See PyAutoFit #1332 F10 and autofit_workspace_test graphical/ep.py.


### PR DESCRIPTION
## Why

EP is not release-ready, so every EP script in the release matrix is being
parked. This is the `autofit_workspace` half; the root-cause investigation and
the failing script live in
**autofit_workspace_test#82** (`scripts/graphical/ep.py`).

`scripts/features/expectation_propagation.py` passes today. It is parked
because it shares the EP machinery whose message projection is unstable, not
because it is currently failing.

## Root cause (summary — full detail in autofit_workspace_test#82)

The 2026-08-03 nightly release integrate failed on `graphical/ep.py`
(PyAutoHeart run 30788224561). Reproduced locally under the release profile:

- A truncated per-factor search projects a posterior with an **effective sample
  size of 1** — a single sample carries all the weight, so the weighted std of
  every parameter is exactly `0`.
- EP feeds that degenerate projection back as the next cycle's prior (`q*`
  arrives already collapsed: `q*_sigma=1.5e-06` against a healthy
  `cavity_sigma=30`).
- The next search draws initial points that all yield an identical log
  likelihood → `InitializerException`.

Damping does not help (`q*` is degenerate before damping applies) and
`check_sigma_collapse` misses it (the collapse is a single-step drop, not the
monotone shrinkage it looks for). See PyAutoFit #1332 F10.

## Change

One `NEEDS_FIX`-tagged entry in `config/build/no_run.yaml`, so every mega-run
surfaces it with a warning banner until EP is fixed.

## Verification

- Pattern is `.py`-anchored and checked against the runner's own `should_skip`:
  **exactly 1** script newly skipped, no over-match, not inert.
- Parses via `find_needs_fix_skips` with the correct date and reason.
- Verified by pattern-match rather than a full shard run (the shard is slow);
  the equivalent end-to-end runner check was done in autofit_workspace_test#82,
  where it exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)