### PR TITLE
docs: make the multi-start batch_size decision explicit

### DIFF
--- a/notebooks/searches/mle.ipynb
+++ b/notebooks/searches/mle.ipynb
@@ -379,6 +379,7 @@
     "    path_prefix=\"searches\",\n",
     "    name=\"MultiStartAdam\",\n",
     "    n_starts=16,\n",
+    "    batch_size=None,  # Starts evaluated at once: `None` vmaps all 16 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.\n",
     "    n_steps=500,\n",
     "    learning_rate=0.5,\n",
     ")\n",

--- a/scripts/searches/mle.py
+++ b/scripts/searches/mle.py
@@ -243,6 +243,7 @@ search = af.MultiStartAdam(
     path_prefix="searches",
     name="MultiStartAdam",
     n_starts=16,
+    batch_size=None,  # Starts evaluated at once: `None` vmaps all 16 together, which is fastest but allocates the whole batched gradient; set an integer (e.g. 4) if you hit an out-of-memory error.
     n_steps=500,
     learning_rate=0.5,
 )


### PR DESCRIPTION
For PyAutoLabs/PyAutoFit#1452.

## What and why

PyAutoLabs/PyAutoHands#228 added a static check that flags any `MultiStart*` search constructed without an explicit `batch_size`. Defaulting to `None` evaluates every start in a single `jax.vmap`, materializing the whole batched `value_and_grad` — which is how two workspace interferometer scripts inherited an unbounded 48-way vmap and OOMed two nightly release runs.

One site here: `scripts/searches/mle.py:245` (`MultiStartAdam`, `n_starts=16`).

## Behaviour is unchanged

`batch_size=None` is already the default, so nothing changes at runtime. The choice is now written down where a reviewer sees it, with a pointer to the knob if a reader hits a memory limit.

This is a 1D toy likelihood at 16 starts, so no bounded value is warranted — the annotation exists so the next author makes the decision deliberately rather than inheriting it.

## Scripts changed

- `scripts/searches/mle.py` — one line; `notebooks/searches/mle.ipynb` regenerated to match (byte-preserving insert, re-verified as valid JSON)

Merge before PyAutoLabs/PyAutoHands#229, which turns the check into a required job.

---
_Generated by [Claude Code](https://claude.ai/code/session_0171voyyTrr91hJ3vU5AjeVz)_