### PR TITLE
fix: keep the smoke runner alive when jupyter is missing

### DIFF
--- a/.github/scripts/run_smoke.py
+++ b/.github/scripts/run_smoke.py
@@ -8,6 +8,12 @@ runs each listed entry with the appropriate environment. Continues
 through failures and exits non-zero if any entry failed.
 
 Notebook execution uses `jupyter nbconvert --to notebook --execute`.
+If `jupyter` is not installed the notebook entries are reported as
+per-entry failures (exit 127) rather than aborting the run: the runner's
+contract is to continue through failures and always end with the summary
+line. CI images always ship jupyter, so this only bites a local sweep --
+where an abort would print a raw traceback and silently discard coverage
+of every remaining entry.
 On failure the runner regenerates the single failing notebook from its
 source `.py` script via PyAutoHands's `py_to_notebook` and retries
 once — this catches stale notebooks where the script has moved on but
@@ -45,6 +51,16 @@ NOTEBOOK_FILE = WORKSPACE / "smoke_notebooks.txt"
 ENV_VARS_FILE = WORKSPACE / "config" / "build" / "profile_smoke.yaml"
 SCRIPTS_DIR = WORKSPACE / "scripts"
 NOTEBOOKS_DIR = WORKSPACE / "notebooks"
+
+# Exit code reported for a notebook entry when the `jupyter` executable is
+# absent, mirroring the shell's "command not found". Distinct from any code
+# nbconvert itself returns, so run_notebook can recognise the case.
+JUPYTER_MISSING_RC = 127
+JUPYTER_MISSING_MSG = (
+    "jupyter not found on PATH: cannot execute notebooks.\n"
+    "Install it with `pip install jupyter` to cover the notebook entries; "
+    "the script entries above are unaffected.\n"
+)
 
 # CI puts PyAutoHands/autohands on PYTHONPATH (PyAutoHeart's reusable
 # smoke-tests.yml clones it alongside the dependency chain); for local runs,
@@ -113,24 +129,31 @@ def execute_notebook(nb_path: Path, env: dict) -> tuple[int, str]:
     staged = WORKSPACE / f".smoke_run_{os.getpid()}_{nb_path.name}"
     shutil.copyfile(nb_path, staged)
     try:
-        result = subprocess.run(
-            [
-                "jupyter",
-                "nbconvert",
-                "--to",
-                "notebook",
-                "--execute",
-                "--output-dir",
-                str(tmp_dir),
-                "--output",
-                nb_path.name,
-                str(staged),
-            ],
-            cwd=str(WORKSPACE),
-            env=env,
-            capture_output=True,
-            text=True,
-        )
+        try:
+            result = subprocess.run(
+                [
+                    "jupyter",
+                    "nbconvert",
+                    "--to",
+                    "notebook",
+                    "--execute",
+                    "--output-dir",
+                    str(tmp_dir),
+                    "--output",
+                    nb_path.name,
+                    str(staged),
+                ],
+                cwd=str(WORKSPACE),
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            # `jupyter` is not installed. Report a per-entry failure instead of
+            # letting the exception escape main(), which would abort the run
+            # with a raw traceback, print no summary line, and leave every
+            # remaining entry silently uncovered.
+            return JUPYTER_MISSING_RC, JUPYTER_MISSING_MSG
     finally:
         staged.unlink(missing_ok=True)
         shutil.rmtree(tmp_dir, ignore_errors=True)
@@ -169,6 +192,10 @@ def run_notebook(nb_rel: str, cfg: dict | None) -> tuple[str, int, float, str]:
         return nb_rel, 1, 0.0, f"Notebook not found: {nb_path}\n"
 
     rc, output = execute_notebook(nb_path, env)
+    if rc == JUPYTER_MISSING_RC:
+        # No jupyter, so regenerating the notebook and retrying cannot help.
+        # Checked before the skip guard so a missing tool is never a PASS.
+        return nb_rel, rc, time.time() - t0, output
     if rc != 0 and is_clean_skip_exit(output):
         # Optional-dependency skip guard (`sys.exit(0)`): a clean exit 0 as a
         # `.py` script, so the notebook form is a PASS too (PyAutoHands#198).


### PR DESCRIPTION
Sibling of PyAutoLabs/autolens_workspace#471 — tracking issue PyAutoLabs/autolens_workspace#470. Identical patch.

## What changed

`.github/scripts/run_smoke.py::execute_notebook` shelled out to a bare `jupyter` argv with no `FileNotFoundError` guard. On a machine without jupyter the exception escaped `main()`: the run died with a raw traceback at the **first** notebook entry, printed no `=== Smoke test summary ===` line, and left every remaining entry silently uncovered. The script leg was never affected — it invokes `sys.executable`, which always exists.

That is a **contract break**, not just a missing optional tool: the runner is documented (module docstring, and this repo's `AGENTS.md`) to continue through failures and always end with the summary line. CI never saw it because the runner images always ship jupyter, so it only bit a local sweep — where it looked like a crash and quietly discarded coverage.

The fix catches `FileNotFoundError` and reports the entry as a failure with exit 127 and an actionable message. Three details worth review attention:

- The guard **nests inside the existing `try/finally`**, so the staged notebook copy and temp dir are still cleaned up.
- `run_notebook`'s early return sits **before** the `is_clean_skip_exit` branch, so an absent executor can never be laundered into a PASS.
- It also **skips the regenerate-and-retry**, which cannot help when the executor itself is missing.

## Scope

Only three of the 10 `run_smoke.py` copies carry the notebook leg — this repo, `autogalaxy_workspace`, `autolens_workspace`. The other seven have no `execute_notebook` at all and cannot hit this bug. The identical patch went into all three; this repo and `autolens_workspace` were byte-identical before and remain so.

Consolidating the copies is deliberately **not** done here — it is owned by a separate PyAutoMind prompt, re-scoped in the same session after measurement showed its premise was stale. Full rationale in PyAutoLabs/autolens_workspace#471.

## Verification

jupyter is genuinely absent in the session container, so the original traceback was reproduced first, then the real runner re-run: **exit 1, both notebook entries `[FAIL (exit 127)]` with an actionable message, all 10 entries executed and counted, summary line printed, no escaped traceback.** Normal path confirmed unchanged with a stub `jupyter` exiting 3 — reported 3, not 127, and still retried.

**Caveat:** the PyAuto libraries are not installed in that container, so every *script* entry also failed on `ImportError`. Unrelated to this change — and it is the ideal evidence, since it exercises the continue-through-failures path the fix defends. Not evidence that those scripts are broken; CI has the libraries and is the real check.

## Scripts Changed

None — `scripts/` is untouched, so no notebook regeneration is needed. Only `.github/scripts/run_smoke.py` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWj2zyGu6ptvqTS8drWhaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWj2zyGu6ptvqTS8drWhaJ)_