### PR TITLE
docs: mark the 2 data.json auto-simulate guards as intentionally raw

### DIFF
--- a/notebooks/features/graphical_models.ipynb
+++ b/notebooks/features/graphical_models.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "import matplotlib.pyplot as plt\n",
@@ -141,6 +141,8 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
+    "# Intentional raw guard: this guards a single file, and this workspace has no\n",
+    "# should_simulate / PYAUTO_SMALL_DATASETS contract (unlike autolens/autogalaxy).\n",
     "if not path.exists(\n",
     "    path.join(\"dataset\", \"example_1d\", \"gaussian_x1__low_snr\", \"dataset_0\", \"data.json\")\n",
     "):\n",

--- a/notebooks/features/shared_analysis_state.ipynb
+++ b/notebooks/features/shared_analysis_state.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "import matplotlib.pyplot as plt\n",
@@ -147,6 +147,8 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
+    "# Intentional raw guard: this guards a single file, and this workspace has no\n",
+    "# should_simulate / PYAUTO_SMALL_DATASETS contract (unlike autolens/autogalaxy).\n",
     "if not path.exists(\n",
     "    path.join(\"dataset\", \"example_1d\", \"gaussian_x1__low_snr\", \"dataset_0\", \"data.json\")\n",
     "):\n",

--- a/scripts/features/graphical_models.py
+++ b/scripts/features/graphical_models.py
@@ -71,6 +71,8 @@ __Dataset Auto-Simulation__
 If the dataset does not already exist on your system, it will be created by running the corresponding
 simulator script. This ensures that all example scripts can be run without manually simulating data first.
 """
+# Intentional raw guard: this guards a single file, and this workspace has no
+# should_simulate / PYAUTO_SMALL_DATASETS contract (unlike autolens/autogalaxy).
 if not path.exists(
     path.join("dataset", "example_1d", "gaussian_x1__low_snr", "dataset_0", "data.json")
 ):

--- a/scripts/features/shared_analysis_state.py
+++ b/scripts/features/shared_analysis_state.py
@@ -77,6 +77,8 @@ __Dataset Auto-Simulation__
 
 If the dataset does not already exist on your system, it will be created by running the corresponding simulator script.
 """
+# Intentional raw guard: this guards a single file, and this workspace has no
+# should_simulate / PYAUTO_SMALL_DATASETS contract (unlike autolens/autogalaxy).
 if not path.exists(
     path.join("dataset", "example_1d", "gaussian_x1__low_snr", "dataset_0", "data.json")
 ):


### PR DESCRIPTION
## Summary

Decision record for the file-path leg of the raw-guard migration (PyAutoLabs/autolens_workspace#475, split from PyAutoLabs/autolens_workspace#354): the 2 `data.json` auto-simulate guards **keep their raw file guard**, each now marked with a one-line intentional-raw-guard comment so future migration sweeps don't re-flag them.

**Why:** the guards check a file (`.../dataset_0/data.json`), and this workspace has no `should_simulate` namespace and never sets `PYAUTO_SMALL_DATASETS` — the recorded leg-3 rejection: adding an `af.util.should_simulate` plus a new env contract in PyAutoFit would buy zero functional gain.

## Scripts touched

- `scripts/features/graphical_models.py`
- `scripts/features/shared_analysis_state.py`

Comment-only insertions (2 lines per site); no behaviour change.

## Notebooks

Regenerated 1:1 for the 2 touched scripts via PyAutoHands (carries the now-canonical `setup_notebook` activation from PyAutoHands `596967e`; the repo-wide sweep of the other notebooks is left to the next wholesale regeneration). Navigator catalogue unchanged.

## Validation

- `py_compile` 2/2
- Neither script is in `smoke_tests.txt`; branch CI exercises the runtime stack.

Companion PR: PyAutoLabs/autolens_workspace#477 (the 7 `positions.json` guards). No library dependency — no pending-release gate needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT)_