### PR TITLE
build: repo-wide notebook sweep — activate setup_notebook in generated notebooks

### DIFF
--- a/notebooks/cookbooks/analysis.ipynb
+++ b/notebooks/cookbooks/analysis.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import numpy as np\n",

--- a/notebooks/cookbooks/configs.ipynb
+++ b/notebooks/cookbooks/configs.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/cookbooks/latent_variables.ipynb
+++ b/notebooks/cookbooks/latent_variables.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "\n",

--- a/notebooks/cookbooks/model.ipynb
+++ b/notebooks/cookbooks/model.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/cookbooks/model_internal.ipynb
+++ b/notebooks/cookbooks/model_internal.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import numpy as np"

--- a/notebooks/cookbooks/multi_level_model.ipynb
+++ b/notebooks/cookbooks/multi_level_model.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/cookbooks/multiple_datasets.ipynb
+++ b/notebooks/cookbooks/multiple_datasets.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/cookbooks/result.ipynb
+++ b/notebooks/cookbooks/result.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "from os import path\n",

--- a/notebooks/cookbooks/samples.ipynb
+++ b/notebooks/cookbooks/samples.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autofit.plot as aplt\n",

--- a/notebooks/cookbooks/search.ipynb
+++ b/notebooks/cookbooks/search.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/features/expectation_propagation.ipynb
+++ b/notebooks/features/expectation_propagation.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "\n",

--- a/notebooks/features/interpolate.ipynb
+++ b/notebooks/features/interpolate.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",

--- a/notebooks/features/model_comparison.ipynb
+++ b/notebooks/features/model_comparison.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/features/search_chaining.ipynb
+++ b/notebooks/features/search_chaining.ipynb
@@ -119,7 +119,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -705,7 +705,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import json\n",
     "import os\n",

--- a/notebooks/features/search_grid_search.ipynb
+++ b/notebooks/features/search_grid_search.ipynb
@@ -101,7 +101,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -96,7 +96,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/overview/overview_1_the_basics.ipynb
+++ b/notebooks/overview/overview_1_the_basics.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import autofit as af\n",
     "import autofit.plot as aplt\n",

--- a/notebooks/overview/overview_2_scientific_workflow.ipynb
+++ b/notebooks/overview/overview_2_scientific_workflow.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from typing import Optional\n",

--- a/notebooks/plot/dynesty_plotter.ipynb
+++ b/notebooks/plot/dynesty_plotter.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/plot/emcee_plotter.ipynb
+++ b/notebooks/plot/emcee_plotter.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/plot/get_dist.ipynb
+++ b/notebooks/plot/get_dist.ipynb
@@ -84,7 +84,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "\n",
     "import numpy as np\n",

--- a/notebooks/plot/nautilus_plotter.ipynb
+++ b/notebooks/plot/nautilus_plotter.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",

--- a/notebooks/plot/zeus_plotter.ipynb
+++ b/notebooks/plot/zeus_plotter.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/searches/mcmc.ipynb
+++ b/notebooks/searches/mcmc.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/mle.ipynb
+++ b/notebooks/searches/mle.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/nest.ipynb
+++ b/notebooks/searches/nest.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/notebooks/searches/start_point.ipynb
+++ b/notebooks/searches/start_point.ipynb
@@ -105,7 +105,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from os import path\n",

--- a/notebooks/simulators/simulators.ipynb
+++ b/notebooks/simulators/simulators.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "from os import path\n",
     "\n",

--- a/notebooks/simulators/simulators_sample.ipynb
+++ b/notebooks/simulators/simulators_sample.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "# from autofit import setup_notebook; setup_notebook()\n",
+    "from autofit import setup_notebook; setup_notebook()\n",
     "\n",
     "import numpy as np\n",
     "from os import path\n",


### PR DESCRIPTION
## Summary

Wholesale notebook regeneration via PyAutoHands, clearing the sweep debt recorded in PyAutoLabs/autolens_workspace#475: since PyAutoHands `596967e` (merged 2026-08-06) the generator uncomments `from autofit import setup_notebook; setup_notebook()` in every generated notebook, but the notebooks predating that fix carried the commented (inactive) form.

## Changes

- **29 notebooks** — the `setup_notebook` line activated. The diff is purely that line: verified mechanically that every changed line contains `setup_notebook`.
- **No scripts touched**; navigator catalogue regenerated identical.

Companion PR: PyAutoLabs/autolens_workspace#479 (same sweep, 285 notebooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGua3k2WDPVrtvj4MTMUoT)_