### PR TITLE
docs: show opt-in EP updater in workspace

### DIFF
--- a/notebooks/features/expectation_propagation.ipynb
+++ b/notebooks/features/expectation_propagation.ipynb
@@ -438,10 +438,16 @@
     "__Full EP Fit__\n",
     "\n",
     "That is the entire algorithm. The high-level API runs this loop for us: `factor_graph.optimise(...)` cycles the\n",
-    "factors, manages damping, tracks the history and writes results to the output folder.\n",
+    "factors, tracks the history and writes results to the output folder. By default it uses full updates (`delta=1.0`),\n",
+    "so damping is not enabled unless we explicitly pass an updater.\n",
     "\n",
     "Each `AnalysisFactor` is fitted by its own `DynestyStatic`; the `LaplaceOptimiser` passed here is the *default* for\n",
-    "the remaining factors \u2014 the `PriorFactor`'s \u2014 whose updates are cheap."
+    "the remaining factors \u2014 the `PriorFactor`'s \u2014 whose updates are cheap.\n",
+    "\n",
+    "For a problem where partial updates are worth testing, add\n",
+    "`updater=af.SimplerUpdater(delta=0.7)` to the call below. This is deliberately commented out: damping is\n",
+    "problem-dependent and has made hierarchical scale collapse worse in repeated-run diagnostics, so it should be\n",
+    "validated across repeated fits rather than enabled routinely."
    ]
   },
   {
@@ -456,6 +462,7 @@
     "    optimiser=laplace,\n",
     "    paths=paths,\n",
     "    ep_history=af.EPHistory(kl_tol=0.05),\n",
+    "    # updater=af.SimplerUpdater(delta=0.7),  # Optional; no damping by default.\n",
     "    max_steps=5,\n",
     ")"
    ],

--- a/scripts/features/expectation_propagation.py
+++ b/scripts/features/expectation_propagation.py
@@ -285,10 +285,16 @@ no search needed). Iterations repeat until the KL change converges.
 __Full EP Fit__
 
 That is the entire algorithm. The high-level API runs this loop for us: `factor_graph.optimise(...)` cycles the
-factors, manages damping, tracks the history and writes results to the output folder.
+factors, tracks the history and writes results to the output folder. By default it uses full updates (`delta=1.0`),
+so damping is not enabled unless we explicitly pass an updater.
 
 Each `AnalysisFactor` is fitted by its own `DynestyStatic`; the `LaplaceOptimiser` passed here is the *default* for
 the remaining factors — the `PriorFactor`'s — whose updates are cheap.
+
+For a problem where partial updates are worth testing, add
+`updater=af.SimplerUpdater(delta=0.7)` to the call below. This is deliberately commented out: damping is
+problem-dependent and has made hierarchical scale collapse worse in repeated-run diagnostics, so it should be
+validated across repeated fits rather than enabled routinely.
 """
 laplace = af.LaplaceOptimiser()
 
@@ -298,6 +304,7 @@ factor_graph_result = factor_graph.optimise(
     optimiser=laplace,
     paths=paths,
     ep_history=af.EPHistory(kl_tol=0.05),
+    # updater=af.SimplerUpdater(delta=0.7),  # Optional; no damping by default.
     max_steps=5,
 )
 


### PR DESCRIPTION
## Summary

- document that expectation-propagation optimisation is undamped by default
- show how to opt in with `af.SimplerUpdater(delta=...)`
- regenerate the canonical notebook from the updated tutorial script
- keep the workspace change gated on the upstream PyAutoFit PR merging first

## Scripts Changed

- `scripts/features/expectation_propagation.py` — documents the undamped default and demonstrates the optional `af.SimplerUpdater`
- `notebooks/features/expectation_propagation.ipynb` — regenerated canonical notebook output

## Upstream PR

- https://github.com/PyAutoLabs/PyAutoFit/pull/1457

## Test Plan

- direct execution of the changed tutorial script: passed
- notebook matches canonical PyAutoHands generation exactly
- PyAutoFit suite: 1667 passed, 6 skipped
- downstream smoke scripts:
  - AutoFit: 8/8 passed
  - AutoGalaxy: 13/13 passed
  - AutoLens: 35/35 passed
  - Euclid: 6/6 passed
- human-acknowledged environment limitations:
  - exact Heart gate reports RED because PyAutoFit is intentionally on `feature/ep-optimise-updater`, not `main`
  - notebook kernels cannot start in this sandbox: `ZMQError: Operation not permitted (addr='ipc://kernel-ipc-1')`
  - the broad AutoLens integration runtime ended with `fatal library error, lookup self`

Merge only after the upstream PyAutoFit PR is merged.

Generated with ChatGPT Codex.
