### PR TITLE
fix(features): run sensitivity mapping in serial so the release leg stops hanging

### DIFF
--- a/notebooks/features/sensitivity_mapping.ipynb
+++ b/notebooks/features/sensitivity_mapping.ipynb
@@ -728,8 +728,10 @@
     "example, normalization has a `LogUniformPrior` with lower limit 1e-4 and upper limit 1e2, therefore the `number_of_steps` \n",
     "of 2 wills imulate and fit just 2 datasets where the intensities between 1e-4 and 1e2.\n",
     "\n",
-    "- `number_of_cores`: The number of cores over which the sensitivity mapping is performed, enabling parallel processing\n",
-    "if set above 1."
+    "- `number_of_cores`: The number of cores over which the sensitivity mapping is performed. If `number_of_cores=1`, the\n",
+    "sensitivity mapping is run in serial. For > 1 core, the simulate-and-fit of each dataset is farmed out to a separate\n",
+    "process. In case your laptop has limited hardware resources we do not run in parallel in this example by default, but\n",
+    "feel free to raise it if you have a lot of CPUs and memory!"
    ]
   },
   {
@@ -751,7 +753,7 @@
     "    base_fit_cls=BaseFit(analysis_cls=Analysis),\n",
     "    perturb_fit_cls=PerturbFit(analysis_cls=Analysis),\n",
     "    number_of_steps=2,\n",
-    "    number_of_cores=2,\n",
+    "    number_of_cores=1,\n",
     ")\n",
     "sensitivity_result = sensitivity.run()"
    ],

--- a/scripts/features/sensitivity_mapping.py
+++ b/scripts/features/sensitivity_mapping.py
@@ -524,8 +524,10 @@ returns the goodness-of-fit of the model to the data.
 example, normalization has a `LogUniformPrior` with lower limit 1e-4 and upper limit 1e2, therefore the `number_of_steps` 
 of 2 wills imulate and fit just 2 datasets where the intensities between 1e-4 and 1e2.
 
-- `number_of_cores`: The number of cores over which the sensitivity mapping is performed, enabling parallel processing
-if set above 1.
+- `number_of_cores`: The number of cores over which the sensitivity mapping is performed. If `number_of_cores=1`, the
+sensitivity mapping is run in serial. For > 1 core, the simulate-and-fit of each dataset is farmed out to a separate
+process. In case your laptop has limited hardware resources we do not run in parallel in this example by default, but
+feel free to raise it if you have a lot of CPUs and memory!
 """
 paths = af.DirectoryPaths(
     path_prefix=path.join("features"),
@@ -542,7 +544,7 @@ sensitivity = af.Sensitivity(
     base_fit_cls=BaseFit(analysis_cls=Analysis),
     perturb_fit_cls=PerturbFit(analysis_cls=Analysis),
     number_of_steps=2,
-    number_of_cores=2,
+    number_of_cores=1,
 )
 sensitivity_result = sensitivity.run()
 


### PR DESCRIPTION
Clears the single script blocking release readiness: `scripts/features/sensitivity_mapping.py` TIMEOUTs at exactly 1800s in `integrate / run_scripts (3.12, autofit, features)`, taking the whole release verdict RED.

## This is a hang, not a budget overrun

From the failing run ([31923788891](https://github.com/PyAutoLabs/PyAutoHeart/actions/runs/31923788891)):

```
graphical_models.py       PASS (14.7s)
interpolate.py            PASS (10.9s)
model_comparison.py       PASS ( 5.9s)
search_chaining.py        PASS (10.3s)
search_grid_search.py     PASS (12.0s)
sensitivity_mapping.py    TIMEOUT (1800s)
shared_analysis_state.py  PASS ( 4.9s)
```

Every sibling finishes in 5–15s under the same release profile. This script's entire workload is **four** reduced nested-sampling fits of a 1D Gaussian (`number_of_steps=2`, base + perturb). That cannot be 30 minutes — it sat at the cap until the harness killed it. Raising `BUILD_SCRIPT_TIMEOUT` would only make the release leg take longer to fail.

## Why this script and not the others

It is the only script in the workspace that actually enables multiprocessing (`number_of_cores=2`), and the release profile is the only profile that combines that with a live JAX (`PYAUTO_DISABLE_JAX=0`) and a real sampler (`PYAUTO_TEST_MODE=1`). Under the smoke profile JAX is disabled and the sampler is bypassed — which is why the per-PR gate never caught this.

## The fix

Default to serial, following the convention already established in this same directory by `search_grid_search.py`, which runs its grid with `number_of_cores=1` and its parallel options commented out alongside the note that parallelism there is delicate (`force_x1_cpu=True — ensures parallelizing over grid search works`). The surrounding prose now matches that script's wording, so the reader is still told they can raise it. Four small fits are fast in serial, so nothing is lost by the example running this way.

Notebook mirror updated to match.

## Verification

- `python -m py_compile` on the script; notebook re-validated as JSON (36 cells intact).
- The diff is exactly the two intended changes in each file — no incidental reformatting.
- **Not executed locally**: this workspace's libraries are not installed in the authoring environment, so the real confirmation is the release leg itself.

## Note on sequencing

Merging this does **not** by itself move Heart's verdict off RED. `release-integrate.yml` is `workflow_dispatch`-only, and `release_run.py` ingests the latest run of that workflow — still the failed 31923788891. A fresh release-integrate dispatch has to run and be ingested before the `release validation FAILED (stage run_scripts)` reason clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_0194NVZM3fi79ErZ3zooCZWq)_