### PR TITLE
Add the missing setup_notebook() line to overview_3_statistical_methods

### DIFF
--- a/notebooks/overview/overview_3_statistical_methods.ipynb
+++ b/notebooks/overview/overview_3_statistical_methods.ipynb
@@ -166,6 +166,16 @@
     "\n",
     "_setup_colab.setup(\"autofit\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "\n",
+    "from autofit import setup_notebook; setup_notebook()"
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/scripts/overview/overview_3_statistical_methods.py
+++ b/scripts/overview/overview_3_statistical_methods.py
@@ -123,3 +123,5 @@ This overview is split into the following sections:
 - **Search Chaining**: Chain a sequence of non-linear searches with increasing model complexity.
 - **Sensitivity Mapping**: Determine the data quality needed for complex models to be favored.
 """
+
+# from autofit import setup_notebook; setup_notebook()


### PR DESCRIPTION
## What

Adds the standard boilerplate line

```python
# from autofit import setup_notebook; setup_notebook()
```

to the one script in this repo that never had it, and updates its generated notebook to match.

| Script | Notebook |
|---|---|
| `scripts/overview/overview_3_statistical_methods.py` | `notebooks/overview/overview_3_statistical_methods.ipynb` |

## Why

`setup_notebook()` chdir's to the workspace root and enables inline plotting. Without it, a script that loads data by a relative path fails when executed by nbconvert, which runs with CWD set to the notebook's own directory — it works interactively only if the user happens to launch jupyter from the repo root.

The other 31 example scripts in this repo carry the line; this one was missed. It is prose-only (a single module docstring, no code), so this is a consistency fix rather than a live breakage — the notebook gains a code cell where it previously had only the Colab setup cell. Say the word if you'd rather it stayed pure markdown.

## Placement

Immediately after the module docstring, matching the sibling convention exactly. The `.py` keeps the line commented; the notebook generator strips the `# ` when it emits the code cell, which is what the notebook side of this diff shows.

## Notebooks

Patched by hand rather than regenerated — PyAutoHands isn't available in the session that produced this. The edit reproduces the generator's output shape exactly (verified against already-correct sibling pairs in this repo, and `json.dumps(nb, indent=1)` round-trips the file byte-identically), so a real `generate.py` run should be a no-op. Worth confirming before merge if you want belt and braces.

No `pending-release` gate applies: `setup_notebook` is long-shipped in released `autofit` and is already called by every other example script here.

## Scope

One leg of a full audit of the `setup_notebook` line across the three HowTo repos and all five user-facing workspaces — 39 scripts missing it in total (HowToFit 3, HowToGalaxy 2, HowToLens 6, autofit_workspace 1, autogalaxy_workspace 5, autolens_workspace 22; autocti_workspace was already clean). `autoreduce_workspace` and every `*_workspace_test` / `*_workspace_developer` repo are deliberately excluded: none of them generates notebooks, so the convention doesn't apply there yet.

Tracked in PyAutoMind as `howto-setup-notebook-audit`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0126SmBwHMzP4okcjhjPoLFZ)_