### PR TITLE
docs: JAX installs by default — retire [jax]-extra install prose (PyAutoLens#702)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-autofit[jax]
+autofit


### PR DESCRIPTION
## Summary
Docs-only migration for JAX becoming a default dependency (PyAutoLens#702): install prose no longer recommends the retired `[jax]` extra (it survives upstream as a no-op alias, so nothing here would have broken — this is prose currency, not a fix). `requirements.txt` drops the extra suffix. Notebooks regenerated from scripts via `generate.py`; the `markdown/` mirror pages received the identical sentence replacements by hand (running `generate_markdown.py` executes every curated script to re-capture figures — disproportionate for prose-only changes; the next curated regen produces this same text).

**Hold for release (pending-release):** the new prose states JAX installs by default, which is true only from the first release containing the upstream promotion.

## Scripts Changed
- `requirements.txt` — `autofit[jax]` → `autofit` (no script prose referenced the extra)

## Upstream PR
https://github.com/PyAutoLabs/PyAutoFit/pull/1503

## Test Plan
- [ ] Workspace smoke CI green on this PR

Generated by the PyAutoLabs agent workflow.
