### PR TITLE
fix: print the final sample instead of hardcoded index 9 (#140)

### DIFF
--- a/scripts/cookbooks/result.py
+++ b/scripts/cookbooks/result.py
@@ -424,8 +424,8 @@ sampled using the fit or an instance of the maximum likelihood model.
 The `Samples` class is described fully in the results cookbook.
 """
 for samples in agg.values("samples"):
-    print("The tenth sample`s third parameter")
-    print(samples.parameter_lists[9][2], "\n")
+    print("The final sample`s third parameter")
+    print(samples.parameter_lists[-1][2], "\n")
 
     instance = samples.max_log_likelihood()
 


### PR DESCRIPTION
## Summary
Part of PyAutoLabs/autofit_workspace#140 (one PR per affected repo). `cookbooks/result.py` printed `samples.parameter_lists[9][2]` ("the tenth sample"), which raises `IndexError` for any stored run with fewer than 10 samples (e.g. `PYAUTO_TEST_MODE` sweeps). Unified to the final sample via `[-1]` with matching prose.

## Scripts Changed
- `scripts/cookbooks/result.py` — `[9]` → `[-1]`, prose "tenth sample" → "final sample". Notebook twin left to release-time regeneration.

## Test Plan
- [x] `cookbooks/result.py` run under its CI smoke env profile via the workspace runner — PASS (3.9s)

Generated by the PyAutoLabs agent workflow.