### PR TITLE
chore: regenerate result.ipynb for the #140 script change

### DIFF
--- a/notebooks/cookbooks/result.ipynb
+++ b/notebooks/cookbooks/result.ipynb
@@ -635,8 +635,8 @@
    "metadata": {},
    "source": [
     "for samples in agg.values(\"samples\"):\n",
-    "    print(\"The tenth sample`s third parameter\")\n",
-    "    print(samples.parameter_lists[9][2], \"\\n\")\n",
+    "    print(\"The final sample`s third parameter\")\n",
+    "    print(samples.parameter_lists[-1][2], \"\\n\")\n",
     "\n",
     "    instance = samples.max_log_likelihood()\n",
     "\n",


### PR DESCRIPTION
## Summary
Follow-up to #141 (merged): regenerates the notebook twin of `scripts/cookbooks/result.py` via PyAutoHands `generate.py`, per this workspace's convention of committing regenerated notebooks alongside script changes. One unrelated pre-existing notebook drift (`overview_3_statistical_methods.ipynb`) was deliberately left out.

## Test Plan
- [x] `generate.py autofit` reported 32 scripts; diff confined to the one intended notebook.

Generated by the PyAutoLabs agent workflow.