### PR TITLE
docs: add cookbooks folder to scripts README

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -2,6 +2,7 @@ The `scripts` folder contains example scripts for using different **PyAutoFit** 
 
 # Folders (Beginner)
 
+- `cookbooks`: Cookbooks concisely explaining how to use different aspects of **PyAutoFit** (model composition, analysis, searches, results).
 - `overview`: Examples providing a concise overview of **PyAutoFit**'s core features.
 - `plot`: Examples showing how to plot the results of model-fits.
 - `searches`: Examples illustrating how to use and customize every non-linear search in **PyAutoFit**.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,7 @@ The `scripts` folder contains example scripts for using different **PyAutoFit** 
 
 # Folders (Beginner)
 
+- `cookbooks`: Cookbooks concisely explaining how to use different aspects of **PyAutoFit** (model composition, analysis, searches, results).
 - `overview`: Examples providing a concise overview of **PyAutoFit**'s core features.
 - `plot`: Examples showing how to plot the results of model-fits.
 - `searches`: Examples illustrating how to use and customize every non-linear search in **PyAutoFit**.


### PR DESCRIPTION
## Summary
The `scripts/README.md` folder list never names `cookbooks/`, which exists and has its own README. Adds the missing entry (sourced from `scripts/cookbooks/README.md`), and commits the regenerated `notebooks/README.md` mirror per this repo's convention. Found by the 2026-08-19 hygiene refs scan.

Part of the folder-list ref-drift sweep: PyAutoLabs/autogalaxy_workspace#215.

## Scripts Changed
- `scripts/README.md` — added `cookbooks/` to the Folders (Beginner) list
- `notebooks/README.md` — regenerated mirror

## Test Plan
- [x] Entry text sourced from the folder's own README, not inferred from the name
- [x] Hygiene refs re-scan of the branch: finding cleared

Generated by the PyAutoLabs agent workflow.
