### PR TITLE
maintenance: raw-string the LaTeX-carrying docstrings

### DIFF
--- a/scripts/cookbooks/configs.py
+++ b/scripts/cookbooks/configs.py
@@ -205,7 +205,7 @@ search = af.DynestyStatic()
 
 # result = search.fit(model=model, analysis=analysis)
 
-"""
+r"""
 __Modules__
 
 For larger projects, it may not be ideal to have to write a .yaml file for every Python class which acts as a model

--- a/scripts/overview/overview_1_the_basics.py
+++ b/scripts/overview/overview_1_the_basics.py
@@ -100,7 +100,7 @@ plt.ylabel("Signal Value")
 plt.show()
 plt.close()
 
-"""
+r"""
 The 1D signal was generated using a 1D Gaussian profile of the form:
 
 \begin{equation*}


### PR DESCRIPTION
Part of PyAutoLabs/autolens_workspace#491 — one of six independent, prose-only PRs (one per workspace repo). No API surface, so no cross-repo merge ordering.

Non-raw docstrings containing LaTeX are corrupted by Python's escape handling, in two classes — and only one of them is visible:

| | what it is | diagnostic |
|---|---|---|
| **warned** | `\s`, `\l`, `\[` — escapes Python does *not* recognise | `SyntaxWarning` per compile; slated to become `SyntaxError` |
| **silent** | `\t` in `\theta`, `\f` in `\frac`, `\r` in `\rm` | **none at all** — the value is simply corrupted |

**2 literals across 2 files** get the `r` prefix — the smallest of the six. Both sweeps now return zero. Prose is untouched — only the delimiter gains an `r`.

## Verification

- **Baseline regeneration is a no-op** — the generator was run *before* editing and left the tree clean, so generator noise cannot fake the gate below.
- **Runtime values**: 1 corruption repaired, **0 other changes**. Every changed literal's value was compared HEAD vs worktree; the prefix may only ever *remove* corruption. This is the check that catches real mistakes — the regeneration gate structurally cannot, because the generator reads source text, not runtime values.
- **Regenerated with autohands**: `notebooks/`, `markdown/`, `llms-full.txt` and `workspace_index.json` are **all byte-identical** — the diff-empty gate passes exactly.

`scripts/cookbooks/configs.py` needed a hand-approved prefix: its `\sigma` and `\lambda` are LaTeX label values in a YAML config example, with no math delimiters for the automatic matcher to key off. Read and confirmed before applying.

## Left alone deliberately

`scripts/cookbooks/samples.py:410` carries `" \\[-2pt]"` — an **already-escaped** LaTeX line break. In a non-raw literal that is one literal backslash, i.e. correct; adding `r` would double it and change the rendered LaTeX. It emits no warning and corrupts nothing.

More generally the prefix was applied only where **every** backslash sits in a LaTeX context, with an absolute veto on `\\`, escaped quotes and numeric escapes regardless of context.

Unblocked by PyAutoHands#251, which taught the notebook and env parsers to accept an `r"""` opener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTjtx5mdituitiyQYFGn2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTjtx5mdituitiyQYFGn2E)_